### PR TITLE
First end2end tests using the examples/ folder

### DIFF
--- a/test/Eris/ExampleEnd2EndTest.php
+++ b/test/Eris/ExampleEnd2EndTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace Eris;
+use SimpleXMLElement;
+
+class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTheSampleAndSampleShrinkTestShouldBePassing()
+    {
+        $this->runExample('SampleTest.php');
+        $this->assertAllTestsArePassing();
+    }
+
+    private function runExample($testFile)
+    {
+        $examplesDir = realpath(__DIR__ . '/../../examples');
+        $samplesTestCase = $examplesDir . '/' . $testFile;
+        $logFile = tempnam(sys_get_temp_dir(), 'phpunit_log_');
+        $phpunitCommand = "vendor/bin/phpunit --log-junit $logFile $samplesTestCase";
+        exec($phpunitCommand, $output, $returnCode);
+        $this->assertSame(0, $returnCode);
+        $this->results = new SimpleXMLElement(file_get_contents($logFile));
+    }
+
+    private function assertAllTestsArePassing()
+    {
+        $this->assertEquals(0, (string) $this->results->testsuite->attributes()['failures']);
+        $this->assertEquals(0, (string) $this->results->testsuite->attributes()['errors']);
+    }
+}


### PR DESCRIPTION
examples/ should be useful for a new developer wanting to use this project. Due to this nature, many of the tests in that folder should be naturally failing, for example to show shrinking at work:

```
1) ListConcatenationTest::testRightIdentityElement
Summing 42 to 0
Failed asserting that 43 matches expected 42.

/home/giorgio/code/eris/examples/SumTest.php:24
/home/giorgio/code/eris/src/Eris/Quantifier/Evaluation.php:48
/home/giorgio/code/eris/src/Eris/Quantifier/RoundRobinShrinking.php:45
/home/giorgio/code/eris/src/Eris/Quantifier/ForAll.php:26
/home/giorgio/code/eris/src/Eris/Quantifier/Evaluation.php:50
/home/giorgio/code/eris/src/Eris/Quantifier/ForAll.php:28
/home/giorgio/code/eris/examples/SumTest.php:25
```

By running those tests in an external process, this end2end test opens the way to make assertions on the state of the example/ tests:
- SampleTest should be passing in its entirety
- ListConcatenationTest::testRightIdentityElement should fail
- ListConcatenationTest::testRightIdentityElement by showing this error message
