### PR TITLE
Exposing Vector functionality via genVector()

### DIFF
--- a/examples/VectorTest.php
+++ b/examples/VectorTest.php
@@ -1,0 +1,22 @@
+<?php
+use Eris\BaseTestCase;
+
+class VectorTest extends BaseTestCase
+{
+    public function testConcatenationMaintainsLength()
+    {
+        $this->forAll([
+            $this->genVector($this->genNat()),
+            $this->genVector($this->genNat()),
+        ])
+            ->__invoke(function($first, $second) {
+                var_dump($first, $second);
+                $concatenated = array_merge($first, $second);
+                $this->assertEquals(
+                    count($concatenated),
+                    count($first) + count($second),
+                    var_export($first, true) . " and " . var_export($second, true) . " do not maintain their length when concatenated."
+                );
+            });
+    }
+}

--- a/src/Eris/TestTrait.php
+++ b/src/Eris/TestTrait.php
@@ -36,6 +36,11 @@ trait TestTrait
         return new Generator\Natural(0, $this->iterations * 10);
     }
 
+    protected function genVector(Generator $elementGenerator)
+    {
+        return new Generator\Vector($this->iterations * 10, $elementGenerator);
+    }
+
     protected function sample(Generator $generator, $size = 10)
     {
         return Sample::of($generator)->withSize($size);

--- a/test/Eris/ExampleEnd2EndTest.php
+++ b/test/Eris/ExampleEnd2EndTest.php
@@ -14,6 +14,12 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
         $this->assertAllTestsArePassing();
     }
 
+    public function testVectorTests()
+    {
+        $this->runExample('VectorTest.php');
+        $this->assertAllTestsArePassing();
+    }
+
     public function testWhenTests()
     {
         $this->runExample('WhenTest.php');


### PR DESCRIPTION
I could not find any genVector() nor acceptance tests so I added them. Currently the generator returns a constant-length vector, but improving on it is orthogonal to this PR.
