### PR TITLE
More robust natural generator

### DIFF
--- a/src/Eris/Generator/Natural.php
+++ b/src/Eris/Generator/Natural.php
@@ -30,6 +30,8 @@ class Natural implements Generator
 
     public function shrink($element)
     {
+        $this->checkValueToShrink($element);
+
         if ($element > $this->lowerLimit) {
             $element--;
         }
@@ -46,7 +48,7 @@ class Natural implements Generator
             && ($element <= $this->upperLimit);
     }
 
-    public function checkLimits($lowerLimit, $upperLimit)
+    private function checkLimits($lowerLimit, $upperLimit)
     {
         if ((!is_int($lowerLimit)) || (!is_int($upperLimit))) {
             throw new InvalidArgumentException(
@@ -64,6 +66,16 @@ class Natural implements Generator
             throw new InvalidArgumentException(
                 "lower limit must be lower than the upper limit. " .
                 "in this case {$lowerLimit} is not lower than {$upperLimit}."
+            );
+        }
+    }
+
+    private function checkValueToShrink($value)
+    {
+        if (!$this->contains($value)) {
+            throw new InvalidArgumentException(
+                "Cannot shrink {$value} because does not belongs to the domain of " .
+                "Naturals between {$this->lowerLimit} and {$this->upperLimit}"
             );
         }
     }

--- a/test/Eris/Generator/NaturalTest.php
+++ b/test/Eris/Generator/NaturalTest.php
@@ -65,4 +65,13 @@ class NaturalTest extends \PHPUnit_Framework_TestCase
     {
         new Natural("nine", "twenty");
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
+    {
+        $generator = new Natural(2, 4);
+        $generator->shrink(5);
+    }
 }


### PR DESCRIPTION
Added some tests and some strict checks for `Generator\Natural`.

This c22ae65d1ba1a867b65ec7240972ed4302eed4bf can be reverted if the discussion in #21 does not approve it.
