### PR TITLE
Failing test with current Integer Generator

### DIFF
--- a/src/Eris/Generator/Integer.php
+++ b/src/Eris/Generator/Integer.php
@@ -34,7 +34,7 @@ class Integer implements Generator
 
     public function __invoke()
     {
-        $valueWithoutOffset = rand(0, $this->upperLimit - ($this->lowerLimit + 1));
+        $valueWithoutOffset = rand(0, $this->safeLimit());
         return $this->lowerLimit + $valueWithoutOffset;
     }
 
@@ -85,5 +85,20 @@ class Integer implements Generator
                 "Integers between {$this->lowerLimit} and {$this->upperLimit}"
             );
         }
+    }
+
+    private function safeLimit()
+    {
+        if ($this->isIntegerOverflow($this->upperLimit - $this->lowerLimit)) {
+            $safeLowerLimit = $this->lowerLimit + 1 + $this->upperLimit;
+            return $this->upperLimit - $safeLowerLimit;
+        }
+
+        return $this->upperLimit - $this->lowerLimit;
+    }
+
+    private function isIntegerOverflow($value)
+    {
+        return !is_int($value);
     }
 }

--- a/test/Eris/Generator/IntegerTest.php
+++ b/test/Eris/Generator/IntegerTest.php
@@ -109,23 +109,23 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
 
     public function testOverflowIsAvoidedWhenDealingWithMachineLowerLimit()
     {
-        $generator = new Integer(PHP_INT_MIN, 7);
+        $generator = new Integer(ERIS_PHP_INT_MIN, 7);
         $value = $generator();
         $this->assertTrue(
             $generator->contains($value),
             "{$value} does not belongs to the domain of Integers " .
-            "between " . PHP_INT_MIN . " and 7"
+            "between " . ERIS_PHP_INT_MIN . " and 7"
         );
     }
 
     public function testOverflowIsAvoidedWhenLowerLimitIsCloseToTheMachineLimit()
     {
-        $generator = new Integer(PHP_INT_MIN + 4, 7);
+        $generator = new Integer(ERIS_PHP_INT_MIN + 4, 7);
         $value = $generator();
         $this->assertTrue(
             $generator->contains($value),
             "{$value} does not belongs to the domain of Integers " .
-            "between " . (PHP_INT_MIN + 4) . " and 7"
+            "between " . (ERIS_PHP_INT_MIN + 4) . " and 7"
         );
     }
 }

--- a/test/Eris/Generator/IntegerTest.php
+++ b/test/Eris/Generator/IntegerTest.php
@@ -43,6 +43,17 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(-10, $value);
     }
 
+    public function testShouldEventuallyGenerateAllTheValues()
+    {
+        $generator = new Integer(3, 7);
+        $values = [];
+        for ($i = 0; $i < 100; $i++) {
+            $value = $generator();
+            $values[$value] = true;
+        }
+        $this->assertEquals(5, count($values), "Only generated the following values: " . var_export(array_keys($values), true));
+    }
+
     public function testUniformity()
     {
         $generator = new Integer(-10, 10000);

--- a/test/Eris/Generator/IntegerTest.php
+++ b/test/Eris/Generator/IntegerTest.php
@@ -106,4 +106,26 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
         $generator = new Integer(100, 200);
         $generator->shrink(300);
     }
+
+    public function testOverflowIsAvoidedWhenDealingWithMachineLowerLimit()
+    {
+        $generator = new Integer(PHP_INT_MIN, 7);
+        $value = $generator();
+        $this->assertTrue(
+            $generator->contains($value),
+            "{$value} does not belongs to the domain of Integers " .
+            "between " . PHP_INT_MIN . " and 7"
+        );
+    }
+
+    public function testOverflowIsAvoidedWhenLowerLimitIsCloseToTheMachineLimit()
+    {
+        $generator = new Integer(PHP_INT_MIN + 4, 7);
+        $value = $generator();
+        $this->assertTrue(
+            $generator->contains($value),
+            "{$value} does not belongs to the domain of Integers " .
+            "between " . (PHP_INT_MIN + 4) . " and 7"
+        );
+    }
 }


### PR DESCRIPTION
```
1) Eris\Generator\IntegerTest::testShouldEventuallyGenerateAllTheValues
Only generated the following values: array (
        0 => 5,
        1 => 4,
        2 => 3,
        3 => 6,
        )
Failed asserting that 4 matches expected 5.
```