### PR TITLE
From 'assertEquals' to 'assertSame'

### DIFF
--- a/test/Eris/Generator/ElementsTest.php
+++ b/test/Eris/Generator/ElementsTest.php
@@ -19,7 +19,7 @@ class ElementsTest extends \PHPUnit_Framework_TestCase
     public function testASingleValueCannotShrinkGivenThereIsNoExplicitRelationshipBetweenTheValuesInTheDomain()
     {
         $generator = Elements::fromArray(['A', 2, false]);
-        $this->assertEquals(2, $generator->shrink(2));
+        $this->assertSame(2, $generator->shrink(2));
     }
 
     public function testOnlyContainsTheElementsOfTheGivenDomain()

--- a/test/Eris/Generator/FloatTest.php
+++ b/test/Eris/Generator/FloatTest.php
@@ -55,7 +55,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($generator->contains(0.0), "0.0 is contained but it should not be");
         $this->assertFalse($generator->contains(9.0), "9.0 is contained but it should not be");
         $this->assertFalse($generator->contains(0), "0 is contained but it should not be");
-        
+
     }
 
     public function testNumbersAreCastedAtCreation()
@@ -63,7 +63,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             new Float(4.0, 8.0),
             new Float(4, 8)
-        ); 
+        );
     }
 
     /**

--- a/test/Eris/Generator/IntegerTest.php
+++ b/test/Eris/Generator/IntegerTest.php
@@ -20,7 +20,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue(in_array(abs($value - $newValue), [0, 1]));
             $value = $newValue;
         }
-        $this->assertEquals(0, $value);
+        $this->assertSame(0, $value);
     }
 
     public function testShrinkStopsAtTheLowerLimitWhenItIsGreaterThanZero()
@@ -30,7 +30,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
         for ($i = 0; $i < 11; $i++) {
             $value = $generator->shrink($value);
         }
-        $this->assertEquals(10, $value);
+        $this->assertSame(10, $value);
     }
 
     public function testShrinkStopsAtTheUpperLimitWhenItIsLowerThanZero()
@@ -40,7 +40,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
         for ($i = 0; $i < 11; $i++) {
             $value = $generator->shrink($value);
         }
-        $this->assertEquals(-10, $value);
+        $this->assertSame(-10, $value);
     }
 
     public function testUniformity()
@@ -61,7 +61,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new Integer($lowerLimit = 0, $upperLimit = 0);
         $lastValue = $generator();
-        $this->assertEquals(0, $generator->shrink($lastValue));
+        $this->assertSame(0, $generator->shrink($lastValue));
     }
 
     /**
@@ -75,8 +75,8 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
     public function testCanGenerateSingleInteger()
     {
         $generator = new Integer(42, 42);
-        $this->assertEquals(42, $generator());
-        $this->assertEquals(42, $generator->shrink($generator()));
+        $this->assertSame(42, $generator());
+        $this->assertSame(42, $generator->shrink($generator()));
     }
 
     /**

--- a/test/Eris/Generator/NaturalTest.php
+++ b/test/Eris/Generator/NaturalTest.php
@@ -14,7 +14,7 @@ class NaturalTest extends \PHPUnit_Framework_TestCase
             }
             $buckets[$value]++;
         }
-        $this->assertEquals($upperLimit, count($buckets));
+        $this->assertSame($upperLimit, count($buckets));
         foreach ($buckets as $bucketValue) {
             // not a statistically correct bound,
             // but should fail very rarely
@@ -27,13 +27,13 @@ class NaturalTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new Natural(1, $upperLimit = 1000);
         $lastValue = $generator();
-        $this->assertEquals($lastValue - 1, $generator->shrink($lastValue));
+        $this->assertSame($lastValue - 1, $generator->shrink($lastValue));
     }
 
     public function testCouldNotShrinkMoreLowerLimit()
     {
         $generator = new Natural(10, 100);
-        $this->assertEquals(10, $generator->shrink(10));
+        $this->assertSame(10, $generator->shrink(10));
     }
 
     /**

--- a/test/Eris/Generator/StringTest.php
+++ b/test/Eris/Generator/StringTest.php
@@ -15,16 +15,16 @@ class StringTest extends \PHPUnit_Framework_TestCase
             $lengths = $this->accumulateLengths($lengths, $length);
             $usedChars = $this->accumulateUsedChars($usedChars, $value);
         }
-        $this->assertEquals(11, count($lengths));
+        $this->assertSame(11, count($lengths));
         // only readable characters
-        $this->assertEquals(127 - 32, count($usedChars));
+        $this->assertSame(127 - 32, count($usedChars));
     }
 
     public function testShrinksByChoppingOffChars()
     {
         $generator = new String(10);
         $lastValue = $generator();
-        $this->assertEquals('abcde', $generator->shrink('abcdef'));
+        $this->assertSame('abcde', $generator->shrink('abcdef'));
     }
 
     public function testCannotShrinkTheEmptyString()

--- a/test/Eris/Generator/TupleTest.php
+++ b/test/Eris/Generator/TupleTest.php
@@ -17,7 +17,7 @@ class TupleTest extends \PHPUnit_Framework_TestCase
 
         $generated = $generator();
 
-        $this->assertEquals(2, count($generated));
+        $this->assertSame(2, count($generated));
         foreach ($generated as $element) {
             $this->assertTrue(
                 $this->generatorForSingleElement->contains($element)
@@ -43,7 +43,7 @@ class TupleTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new Tuple([]);
 
-        $this->assertEquals([], $generator());
+        $this->assertSame([], $generator());
     }
 
     public function testContainsGeneratedElements()
@@ -85,18 +85,18 @@ class TupleTest extends \PHPUnit_Framework_TestCase
         $constants = [42, 42];
         $generator = new Tuple($constants);
         $elements = $generator();
-        $this->assertEquals($constants, $elements);
+        $this->assertSame($constants, $elements);
         $elementsAfterShrink = $generator->shrink($elements);
-        $this->assertEquals($constants, $elementsAfterShrink);
+        $this->assertSame($constants, $elementsAfterShrink);
     }
 
     public function testShrinkNothing()
     {
         $generator = new Tuple([]);
         $elements = $generator();
-        $this->assertEquals([], $elements);
+        $this->assertSame([], $elements);
         $elementsAfterShrink = $generator->shrink($elements);
-        $this->assertEquals([], $elementsAfterShrink);
+        $this->assertSame([], $elementsAfterShrink);
     }
 
     /**

--- a/test/Eris/Generator/VectorTest.php
+++ b/test/Eris/Generator/VectorTest.php
@@ -19,7 +19,7 @@ class VectorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->vectorGenerator;
         $vector = $generator();
 
-        $this->assertEquals($this->vectorSize, count($vector));
+        $this->assertSame($this->vectorSize, count($vector));
         foreach ($vector as $element) {
             $this->assertTrue($this->elementGenerator->contains($element));
         }


### PR DESCRIPTION
After discovering this bite (40e06d1b5952bb8d30b4c6ca9ee06352870e1ced) from the _type juggling_ I propose to switch assertions on the Generators (especially in shrink/1 tests) from `assertEquals` to `assertSame`.
Even if type juggling is a PHP feature, types matters for us. :-)
