### PR TITLE
Date generator

### DIFF
--- a/examples/DateTest.php
+++ b/examples/DateTest.php
@@ -17,4 +17,21 @@ class DateTest extends PHPUnit_Framework_TestCase
                 );
             });
     }
+
+    public function testDefaultValuesForTheInterval()
+    {
+        $this->forAll([
+            Generator\date(),
+        ])
+            ->then(function(DateTime $date) {
+                $this->assertGreaterThanOrEqual(
+                    "1970",
+                    $date->format('Y')
+                );
+                $this->assertLessThanOrEqual(
+                    "2038",
+                    $date->format('Y')
+                );
+            });
+    }
 }

--- a/examples/DateTest.php
+++ b/examples/DateTest.php
@@ -1,0 +1,20 @@
+<?php
+use Eris\Generator;
+
+class DateTest extends PHPUnit_Framework_TestCase
+{
+    use Eris\TestTrait;
+
+    public function testYearOfADate()
+    {
+        $this->forAll([
+            Generator\date("2014-01-01T00:00:00", "2014-12-31T23:59:59"),
+        ])
+            ->then(function(DateTime $date) {
+                $this->assertEquals(
+                    "2014",
+                    $date->format('Y')
+                );
+            });
+    }
+}

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -41,21 +41,15 @@ class Date implements Generator
 
     public function __invoke()
     {
-        $timeOffset = rand(0, $this->intervalInSeconds);
-        $chosenTimestamp = $this->lowerLimit->getTimestamp() + $timeOffset;
-        $element = new DateTime();
-        $element->setTimestamp($chosenTimestamp);
-        return $element;
+        $generatedOffset = rand(0, $this->intervalInSeconds);
+        return $this->fromOffset($generatedOffset);
     }
 
     public function shrink($element)
     {
         $timeOffset = $element->getTimestamp() - $this->lowerLimit->getTimestamp();
         $halvedOffset = floor($timeOffset / 2);
-        $chosenTimestamp = $this->lowerLimit->getTimestamp() + $halvedOffset;
-        $element = new DateTime();
-        $element->setTimestamp($chosenTimestamp);
-        return $element;
+        return $this->fromOffset($halvedOffset);
     }
 
     public function contains($element)
@@ -63,5 +57,17 @@ class Date implements Generator
         return $element instanceof DateTime
             && $element >= $this->lowerLimit
             && $element <= $this->upperLimit;
+    }
+
+    /**
+     * @param integer $offset  seconds to be added to lower limit
+     * @return DateTime
+     */
+    private function fromOffset($offset)
+    {
+        $chosenTimestamp = $this->lowerLimit->getTimestamp() + $offset;
+        $element = new DateTime();
+        $element->setTimestamp($chosenTimestamp);
+        return $element;
     }
 }

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -30,6 +30,7 @@ class Date implements Generator
 {
     private $lowerLimit;
     private $upperLimit;
+    private $intervalInSeconds;
     
     public function __construct(DateTime $lowerLimit, DateTime $upperLimit)
     {

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 use Eris\Generator;
 use DateTime;
+use DomainException;
 
 function date($lowerLimit = null, $upperLimit = null)
 {
@@ -47,6 +48,8 @@ class Date implements Generator
 
     public function shrink($element)
     {
+        $this->ensureIsInDomain($element);
+
         $timeOffset = $element->getTimestamp() - $this->lowerLimit->getTimestamp();
         $halvedOffset = floor($timeOffset / 2);
         return $this->fromOffset($halvedOffset);
@@ -69,5 +72,12 @@ class Date implements Generator
         $element = new DateTime();
         $element->setTimestamp($chosenTimestamp);
         return $element;
+    }
+
+    private function ensureIsInDomain($element)
+    {
+        if (!$this->contains($element)) {
+            throw new DomainException("The element " . var_export($element, true) . " is not part of this generator's domain");
+        }
     }
 }

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -3,6 +3,17 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DateTime;
 
+function date($lowerLimit, $upperLimit)
+{
+    $box = function($date) {
+        if ($date instanceof DateTime) {
+            return $date;
+        }
+        return new DateTime($date);
+    };
+    return new Date($box($lowerLimit), $box($upperLimit));
+}
+
 class Date implements Generator
 {
     private $lowerLimit;

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -1,0 +1,32 @@
+<?php
+namespace Eris\Generator;
+use DateTime;
+
+class Date
+{
+    private $lowerLimit;
+    private $upperLimit;
+    
+    public function __construct(DateTime $lowerLimit, DateTime $upperLimit)
+    {
+        $this->lowerLimit = $lowerLimit;
+        $this->upperLimit = $upperLimit;
+        $this->intervalInSeconds = $upperLimit->getTimestamp() - $lowerLimit->getTimestamp();
+    }
+
+    public function __invoke()
+    {
+        $timeOffset = rand(0, $this->intervalInSeconds);
+        $chosenTimestamp = $this->lowerLimit->getTimestamp() + $timeOffset;
+        $element = new DateTime();
+        $element->setTimestamp($chosenTimestamp);
+        return $element;
+    }
+
+    public function contains($element)
+    {
+        return $element instanceof DateTime
+            && $element >= $this->lowerLimit
+            && $element <= $this->upperLimit;
+    }
+}

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -1,8 +1,9 @@
 <?php
 namespace Eris\Generator;
+use Eris\Generator;
 use DateTime;
 
-class Date
+class Date implements Generator
 {
     private $lowerLimit;
     private $upperLimit;
@@ -20,6 +21,11 @@ class Date
         $chosenTimestamp = $this->lowerLimit->getTimestamp() + $timeOffset;
         $element = new DateTime();
         $element->setTimestamp($chosenTimestamp);
+        return $element;
+    }
+
+    public function shrink($element)
+    {
         return $element;
     }
 

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -50,6 +50,11 @@ class Date implements Generator
 
     public function shrink($element)
     {
+        $timeOffset = $element->getTimestamp() - $this->lowerLimit->getTimestamp();
+        $halvedOffset = floor($timeOffset / 2);
+        $chosenTimestamp = $this->lowerLimit->getTimestamp() + $halvedOffset;
+        $element = new DateTime();
+        $element->setTimestamp($chosenTimestamp);
         return $element;
     }
 

--- a/src/Eris/Generator/Date.php
+++ b/src/Eris/Generator/Date.php
@@ -3,15 +3,27 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DateTime;
 
-function date($lowerLimit, $upperLimit)
+function date($lowerLimit = null, $upperLimit = null)
 {
     $box = function($date) {
+        if ($date === null) {
+            return $date;
+        }
         if ($date instanceof DateTime) {
             return $date;
         }
         return new DateTime($date);
     };
-    return new Date($box($lowerLimit), $box($upperLimit));
+    $withDefault = function($value, $default) {
+        if ($value !== null) {
+            return $value;
+        }
+        return $default;
+    };
+    return new Date(
+        $withDefault($box($lowerLimit), new DateTime("@0")),
+        $withDefault($box($upperLimit), new DateTime("@" . getrandmax()))
+    );
 }
 
 class Date implements Generator

--- a/test/Eris/ExampleEnd2EndTest.php
+++ b/test/Eris/ExampleEnd2EndTest.php
@@ -50,6 +50,12 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
         $this->assertTestsAreFailing(1);
     }
 
+    public function testDateTest()
+    {
+        $this->runExample('DateTest.php');
+        $this->assertAllTestsArePassing();
+    }
+
     public function testSumTests()
     {
         $this->runExample('SumTest.php');

--- a/test/Eris/Generator/DateTest.php
+++ b/test/Eris/Generator/DateTest.php
@@ -25,4 +25,20 @@ class DateTest extends \PHPUnit_Framework_TestCase
             $generator->shrink(new DateTime("2014-01-02T08:00:00"))
         );
     }
+
+    public function testTheLowerLimitIsTheFixedPointOfShrinking()
+    {
+        $generator = new Date(
+            $lowerLimit = new DateTime("2014-01-01T00:00:00"),
+            new DateTime("2014-01-02T23:59:59")
+        );
+        $value = new DateTime("2014-01-01T00:01:00");
+        for ($i = 0; $i < 10; $i++) {
+            $value = $generator->shrink($value);
+        }
+        $this->assertEquals(
+            $lowerLimit,
+            $value
+        );
+    }
 }

--- a/test/Eris/Generator/DateTest.php
+++ b/test/Eris/Generator/DateTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Eris\Generator;
+use DateTime;
+
+class DateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGenerateDateTimeObjectsInTheGivenInterval()
+    {
+        $generator = new Date(
+            new DateTime("2014-01-01T00:00:00"),
+            new DateTime("2014-01-02T23:59:59")
+        );
+        $value = $generator();
+        $this->assertTrue($generator->contains($value));
+    }
+}

--- a/test/Eris/Generator/DateTest.php
+++ b/test/Eris/Generator/DateTest.php
@@ -13,4 +13,14 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $value = $generator();
         $this->assertTrue($generator->contains($value));
     }
+
+    public function testItIsStillUnclearHowCanDateTimeObjectShrink()
+    {
+        $generator = new Date(
+            new DateTime("2014-01-01T00:00:00"),
+            new DateTime("2014-01-02T23:59:59")
+        );
+        $sampleValue = new DateTime("2014-01-01T12:00:00");
+        $this->assertEquals($sampleValue, $generator->shrink($sampleValue));
+    }
 }

--- a/test/Eris/Generator/DateTest.php
+++ b/test/Eris/Generator/DateTest.php
@@ -14,6 +14,19 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($generator->contains($value));
     }
 
+    /**
+     * @expectedException DomainException
+     */
+    public function testCannotShrinkValuesOutsideOfItsDomain()
+    {
+        $generator = new Date(
+            new DateTime("2014-01-01T00:00:00"),
+            new DateTime("2014-01-02T23:59:59")
+        );
+        $value = $generator();
+        $generator->shrink(new DateTime("2014-01-10T00:00:00"));
+    }
+
     public function testDateTimeShrinkGeometrically()
     {
         $generator = new Date(

--- a/test/Eris/Generator/DateTest.php
+++ b/test/Eris/Generator/DateTest.php
@@ -14,13 +14,15 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($generator->contains($value));
     }
 
-    public function testItIsStillUnclearHowCanDateTimeObjectShrink()
+    public function testDateTimeShrinkGeometrically()
     {
         $generator = new Date(
             new DateTime("2014-01-01T00:00:00"),
             new DateTime("2014-01-02T23:59:59")
         );
-        $sampleValue = new DateTime("2014-01-01T12:00:00");
-        $this->assertEquals($sampleValue, $generator->shrink($sampleValue));
+        $this->assertEquals(
+            new DateTime("2014-01-01T16:00:00"),
+            $generator->shrink(new DateTime("2014-01-02T08:00:00"))
+        );
     }
 }


### PR DESCRIPTION
It is not clear to me how to shrink dates: bringing them towards 1970 (or the lower limit) does not seem to simplify much.
Another option would be to shrink in detail:
```
"2014-12-22T14:10:34"
"2014-12-22T14:10:00"
"2014-12-22T14:00:00"
"2014-12-22T00:00:00"
"2014-12-01T00:00:00"
"2014-01-01T00:00:00"
"1970-01-01T00:00:00"
```