### PR TITLE
Error messages

### DIFF
--- a/examples/ErrorTest.php
+++ b/examples/ErrorTest.php
@@ -1,0 +1,17 @@
+<?php
+use Eris\Generator;
+
+class ErrorTest extends \PHPUnit_Framework_TestCase
+{
+    use Eris\TestTrait;
+
+    public function testGenericExceptionsDoNotShrinkButStillShowTheInput()
+    {
+        $this->forAll(
+            Generator\string(10)
+        )
+            ->then(function($string) {
+                throw new RuntimeException("Something like a missing array index happened.");
+            });
+    }
+}

--- a/src/Eris/Quantifier/ForAll.php
+++ b/src/Eris/Quantifier/ForAll.php
@@ -83,13 +83,14 @@ class ForAll
                     ->execute();
             }
         } catch (Exception $e) {
-            if ($e instanceof PHPUnit_Framework_AssertionFailedError) {
+            $wrap = (bool) getenv('ERIS_ORIGINAL_INPUT');
+            if ($wrap) {
+                $message = "Original input: " . var_export($values, true) . PHP_EOL
+                    . "Possibly shrinked input follows." . PHP_EOL;
+                throw new RuntimeException($message, -1, $e);
+            } else {
                 throw $e;
             }
-            if ($e instanceof PHPUnit_Framework_ExpectationFailedException) {
-                throw $e;
-            }
-            throw new RuntimeException("A non-assertion-related exception happened while using the input: " . var_export($values, true), -1, $e);
         }
     }
 

--- a/test/Eris/ExampleEnd2EndTest.php
+++ b/test/Eris/ExampleEnd2EndTest.php
@@ -64,6 +64,17 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
         $this->assertLessThanOrEqual(4.0, $executionTime);
     }
 
+    public function testGenericErrorTest()
+    {
+        $this->runExample('ErrorTest.php');
+        $this->assertTestsAreFailing(1);
+        $errorMessage = (string) $this->theTest('testGenericExceptionsDoNotShrinkButStillShowTheInput')->error;
+        $this->assertRegexp(
+            "/while using the input:/",
+            $errorMessage
+        );
+    }
+
     public function testFloatTests()
     {
         $this->runExample('FloatTest.php');


### PR DESCRIPTION
* Fixes https://github.com/giorgiosironi/eris/issues/36 by providing a way for the user to explicitate the input
* Starts the first shot at https://trello.com/c/3OeQFdkx/32-an-user-can-run-a-test-and-see-what-was-the-first-failed-example-and-the-following-shrinking-process as the whole process is very large, but at least the original failing input and the shrinked one are easy to show.

I will also look into an alternative way of passing parameters, different from environment variables.