### PR TITLE
[RFC] - Generated data distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "phpunit/phpunit": ">4,<6"
     },
     "require-dev": {

--- a/examples/IntegerTest.php
+++ b/examples/IntegerTest.php
@@ -41,6 +41,16 @@ class IntegerTest extends PHPUnit_Framework_TestCase
             });
     }
 
+    public function testGeneratedDataCollection()
+    {
+        $this
+            ->forAll(Generator\neg())
+            ->collect(function($x) { return $x; })
+            ->then(function($x) {
+                $this->assertTrue($x < $x + 1);
+            });
+    }
+
     public function testByteData()
     {
         $this->forAll(

--- a/examples/IntegerTest.php
+++ b/examples/IntegerTest.php
@@ -1,6 +1,7 @@
 <?php
 use Eris\Generator;
 use Eris\TestTrait;
+use Eris\Listener;
 
 class IntegerTest extends PHPUnit_Framework_TestCase
 {
@@ -45,8 +46,7 @@ class IntegerTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(Generator\neg())
-            // TODO: better syntax
-            ->addListener(new \Eris\Listener\CollectFrequencies())
+            ->hook(Listener\collectFrequencies())
             ->then(function($x) {
                 $this->assertTrue($x < $x + 1);
             });

--- a/examples/IntegerTest.php
+++ b/examples/IntegerTest.php
@@ -45,7 +45,8 @@ class IntegerTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(Generator\neg())
-            ->collect(function($x) { return $x; })
+            // TODO: better syntax
+            ->addListener(new \Eris\Listener\CollectFrequencies())
             ->then(function($x) {
                 $this->assertTrue($x < $x + 1);
             });

--- a/examples/SequenceTest.php
+++ b/examples/SequenceTest.php
@@ -16,6 +16,21 @@ class SequenceTest extends PHPUnit_Framework_TestCase
             });
     }
 
+    public function testGeneratedDataCollection()
+    {
+        $this
+            ->forAll(
+                Generator\seq(Generator\nat())
+            )
+            ->withMaxSize(10)
+            ->collect(function($array) {
+                return '[' . implode(',', $array) . ']';
+            })
+            ->then(function($array) {
+                $this->assertEquals(count($array), count(array_reverse($array)));
+            });
+    }
+
     public function testArrayReverse()
     {
         $this

--- a/examples/SequenceTest.php
+++ b/examples/SequenceTest.php
@@ -23,9 +23,9 @@ class SequenceTest extends PHPUnit_Framework_TestCase
                 Generator\seq(Generator\nat())
             )
             ->withMaxSize(10)
-            ->collect(function($array) {
+            ->addListener(new \Eris\Listener\CollectFrequencies(function($array) {
                 return '[' . implode(',', $array) . ']';
-            })
+            }))
             ->then(function($array) {
                 $this->assertEquals(count($array), count(array_reverse($array)));
             });

--- a/examples/SequenceTest.php
+++ b/examples/SequenceTest.php
@@ -1,5 +1,6 @@
 <?php
 use Eris\Generator;
+use Eris\Listener;
 
 class SequenceTest extends PHPUnit_Framework_TestCase
 {
@@ -23,7 +24,7 @@ class SequenceTest extends PHPUnit_Framework_TestCase
                 Generator\seq(Generator\nat())
             )
             ->withMaxSize(10)
-            ->addListener(new \Eris\Listener\CollectFrequencies(function($array) {
+            ->hook(Listener\collectFrequencies(function($array) {
                 return '[' . implode(',', $array) . ']';
             }))
             ->then(function($array) {

--- a/examples/SortTest.php
+++ b/examples/SortTest.php
@@ -9,9 +9,7 @@ class SortTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\seq(
-                    Generator\nat()
-                )
+                Generator\seq(Generator\nat())
             )
             ->then(function($array) {
                 sort($array);

--- a/src/Eris/Listener.php
+++ b/src/Eris/Listener.php
@@ -13,7 +13,6 @@ interface Listener
     /**
      * @param integer
      * @return void
-     * TODO: evaluation vs generation
      */
     public function endPropertyVerification($evaluations);
 

--- a/src/Eris/Listener.php
+++ b/src/Eris/Listener.php
@@ -1,0 +1,25 @@
+<?php
+namespace Eris;
+
+use Eris\Generator\GeneratedValue;
+
+interface Listener
+{
+    /**
+     * @return void
+     */
+    public function startPropertyVerification();
+
+    /**
+     * @param integer
+     * @return void
+     * TODO: evaluation vs generation
+     */
+    public function endPropertyVerification($evaluations);
+
+    /**
+     * @param array  of GeneratedValue
+     * @return void
+     */
+    public function newGeneration(array $generatedValues);
+}

--- a/src/Eris/Listener/CollectFrequencies.php
+++ b/src/Eris/Listener/CollectFrequencies.php
@@ -9,7 +9,9 @@ function collectFrequencies(callable $collectFunction = null)
     return new CollectFrequencies($collectFunction);
 }
 
-class CollectFrequencies implements Listener
+class CollectFrequencies
+    extends EmptyListener
+    implements Listener
 {
     private $collectFunction;
     private $collectedValues = [];
@@ -20,11 +22,6 @@ class CollectFrequencies implements Listener
             $collectFunction = function($value) { return $value; };
         }
         $this->collectFunction = $collectFunction;
-    }
-
-    // TODO: EmptyListener
-    public function startPropertyVerification()
-    {
     }
 
     public function endPropertyVerification($evaluations)

--- a/src/Eris/Listener/CollectFrequencies.php
+++ b/src/Eris/Listener/CollectFrequencies.php
@@ -1,0 +1,55 @@
+<?php
+namespace Eris\Listener;
+
+use Eris\Generator\GeneratedValue;
+use Eris\Listener;
+
+function collectFrequencies(callable $collectFunction = null) 
+{
+    return new CollectFrequencies($collectFunction);
+}
+
+class CollectFrequencies implements Listener
+{
+    private $collectFunction;
+    private $collectedValues = [];
+    
+    public function __construct($collectFunction = null)
+    {
+        if ($collectFunction === null) {
+            $collectFunction = function($value) { return $value; };
+        }
+        $this->collectFunction = $collectFunction;
+    }
+
+    // TODO: EmptyListener
+    public function startPropertyVerification()
+    {
+    }
+
+    public function endPropertyVerification($evaluations)
+    {
+        arsort($this->collectedValues, SORT_NUMERIC);
+        echo PHP_EOL;
+        foreach ($this->collectedValues as $key => $value) {
+            $frequency = round(($value / $evaluations) * 100, 2);
+            echo "{$frequency}%  $key" . PHP_EOL;
+        }
+    }
+
+    public function newGeneration(array $generatedValues)
+    {
+        $values = array_map(
+            function($generatedValue) {
+                return $generatedValue->unbox();
+            },
+            $generatedValues
+        );
+        $key = call_user_func_array($this->collectFunction, $values);
+        if (array_key_exists($key, $this->collectedValues)) {
+            $this->collectedValues[$key]++;
+        } else {
+            $this->collectedValues[$key] = 1;
+        }
+    }
+}

--- a/src/Eris/Listener/EmptyListener.php
+++ b/src/Eris/Listener/EmptyListener.php
@@ -1,0 +1,17 @@
+<?php
+namespace Eris\Listener;
+
+class EmptyListener
+{
+    public function startPropertyVerification()
+    {
+    }
+
+    public function endPropertyVerification($evaluations)
+    {
+    }
+
+    public function newGeneration(array $generatedValues)
+    {
+    }
+}

--- a/src/Eris/Quantifier/ForAll.php
+++ b/src/Eris/Quantifier/ForAll.php
@@ -70,7 +70,7 @@ class ForAll
         return $this;
     }
 
-    public function addListener(Listener $listener)
+    public function hook(Listener $listener)
     {
         $this->listeners[] = $listener;
         return $this;

--- a/src/Eris/Quantifier/ForAll.php
+++ b/src/Eris/Quantifier/ForAll.php
@@ -117,8 +117,6 @@ class ForAll
                     })
                     ->execute();
             }
-            // TODO: finally
-            $this->notifyListeners('endPropertyVerification', $this->evaluations);
         } catch (Exception $e) {
             $wrap = (bool) getenv('ERIS_ORIGINAL_INPUT');
             if ($wrap) {
@@ -128,6 +126,8 @@ class ForAll
             } else {
                 throw $e;
             }
+        } finally {
+            $this->notifyListeners('endPropertyVerification', $this->evaluations);
         }
     }
 

--- a/src/Eris/Quantifier/ForAll.php
+++ b/src/Eris/Quantifier/ForAll.php
@@ -250,8 +250,8 @@ class ForAll
             arsort($this->collectedValues, SORT_NUMERIC);
             echo PHP_EOL;
             foreach ($this->collectedValues as $key => $value) {
-                $probability = round(($value / $this->evaluations) * 100, 2);
-                echo  "{$probability}%  $key" . PHP_EOL;
+                $frequency = round(($value / $this->evaluations) * 100, 2);
+                echo "{$frequency}%  $key" . PHP_EOL;
             }
         }
     }

--- a/src/Eris/TestTrait.php
+++ b/src/Eris/TestTrait.php
@@ -63,6 +63,16 @@ trait TestTrait
     }
 
     /**
+     * @beforeClass
+     */
+    public static function loadAllErisListeners()
+    {
+        foreach(glob(__DIR__ . '/Listener/*.php') as $filename) {
+            require_once($filename);
+        }
+    }
+
+    /**
      * @after
      */
     public function checkConstraintsHaveNotSkippedTooManyIterations()


### PR DESCRIPTION
The main goal of this pull request is to be a little bit less blind on which kind of values have been generated by eris's generators.
Basically we are porting the `eqc:collect/2` (or the `eqc:aggregate/2`) functionality to eris.

The user will be able to set a collection function which will be invoked with the same value of the property evaluation function. The value returned by the "collection function" should uniquely identify the values generated during the property evaluation. So that, at the end of the evaluation we will be able to print some useful information about the distribution of the generated data.

Here are a couple of examples from this spike:
```
39%  []
11%  [0]
5%  [1]
3%  [2]
2%  [0,4,3]
2%  [3]
2%  [2,1]
...
1%  [8,8,5,5]
1%  [9,8,10,7,0,9]
1%  [6,5,10]
1%  [2,2]
1%  [0,5,4,5]
1%  [3,1,1]
```
And:
```
10%  0
6%  -2
6%  -1
4%  -12
4%  -9
3%  -56
...
1%  -41
1%  -7
1%  -91
```

This seems to be a good tool for the user which will be able to tune its generators until the generated values respects a satisfactory distribution.

Obviously the code is "raw and unedited", this is a proof of concept.

What is your feedback?