### PR TITLE
Consistent mathematical definition of pos(), nat() and neg()

### DIFF
--- a/src/Eris/Generator/Integer.php
+++ b/src/Eris/Generator/Integer.php
@@ -20,14 +20,17 @@ function int()
 function pos()
 {
     $mustBePositive = function($n) {
-        return abs($n);
+        return abs($n) + 1;
     };
     return new Integer($mustBePositive);
 }
 
 function nat()
 {
-    return pos();
+    $mustBePositive = function($n) {
+        return abs($n);
+    };
+    return new Integer($mustBePositive);
 }
 
 /**
@@ -36,10 +39,7 @@ function nat()
 function neg()
 {
     $mustBeNegative = function($n) {
-        if ($n > 0) {
-            return $n * (-1);
-        }
-        return $n;
+        return (-1) * (abs($n) + 1);
     };
     return new Integer($mustBeNegative);
 }

--- a/test/Eris/Generator/IntegerTest.php
+++ b/test/Eris/Generator/IntegerTest.php
@@ -52,4 +52,22 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
         $lastValue = $generator($size = 0);
         $this->assertSame(0, $generator->shrink($lastValue));
     }
+
+    public function testPosAlreadyStartsFromStrictlyPositiveValues()
+    {
+        $generator = pos();
+        $this->assertGreaterThan(0, $generator->__invoke(0));
+    }
+
+    public function testNegAlreadyStartsFromStrictlyNegativeValues()
+    {
+        $generator = neg();
+        $this->assertLessThan(0, $generator->__invoke(0));
+    }
+
+    public function testNatStartsFromZero()
+    {
+        $generator = nat();
+        $this->assertEquals(0, $generator->__invoke(0));
+    }
 }


### PR DESCRIPTION
- `nat()` generates an integer in `[0, +oo)`
- `pos()` generates an integer in `[1, +oo)`
- `neg()` generates an integer in `(-oo, -1]`

pos() is particularly useful for amounts of money to use in transactions as they cannot be 0.