### PR TITLE
Rename Float and String generators with valid names for PHP 7

### DIFF
--- a/src/Eris/Generator/FloatGenerator.php
+++ b/src/Eris/Generator/FloatGenerator.php
@@ -6,10 +6,10 @@ use DomainException;
 
 function float()
 {
-    return new Float();
+    return new FloatGenerator();
 }
 
-class Float implements Generator
+class FloatGenerator implements Generator
 {
     public function __construct()
     {

--- a/src/Eris/Generator/StringGenerator.php
+++ b/src/Eris/Generator/StringGenerator.php
@@ -6,10 +6,10 @@ use DomainException;
 
 function string()
 {
-    return new String();
+    return new StringGenerator();
 }
 
-class String implements Generator
+class StringGenerator implements Generator
 {
     public function __construct()
     {

--- a/test/Eris/Generator/FloatGeneratorTest.php
+++ b/test/Eris/Generator/FloatGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Eris\Generator;
 
-class FloatTest extends \PHPUnit_Framework_TestCase
+class FloatGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -10,7 +10,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
 
     public function testPicksUniformelyPositiveAndNegativeFloatNumbers()
     {
-        $generator = new Float();
+        $generator = new FloatGenerator();
         $sum = 0;
         $trials = 500;
         for ($i = 0; $i < $trials; $i++) {
@@ -25,14 +25,14 @@ class FloatTest extends \PHPUnit_Framework_TestCase
 
     public function testShrinksLinearly()
     {
-        $generator = new Float();
+        $generator = new FloatGenerator();
         $this->assertSame(3.5, $generator->shrink(4.5));
         $this->assertSame(-2.5, $generator->shrink(-3.5));
     }
 
     public function testWhenBothSignsArePossibleCannotShrinkBelowZero()
     {
-        $generator = new Float();
+        $generator = new FloatGenerator();
         $this->assertSame(0.0, $generator->shrink(0.0));
         $this->assertSame(0.0, $generator->shrink(0.5));
         $this->assertSame(0.0, $generator->shrink(-0.5));
@@ -43,7 +43,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
     {
-        $generator = new Float(100.12, 200.12);
+        $generator = new FloatGenerator(100.12, 200.12);
         $generator->shrink(300);
     }
 }

--- a/test/Eris/Generator/StringGeneratorTest.php
+++ b/test/Eris/Generator/StringGeneratorTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace Eris\Generator;
 
-class StringTest extends \PHPUnit_Framework_TestCase
+class StringGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testRandomlyPicksLengthAndCharacters()
     {
         $size = 10;
-        $generator = new String();
+        $generator = new StringGenerator();
         $lengths = [];
         $usedChars = [];
         for ($i = 0; $i < 1000; $i++) {
@@ -24,7 +24,7 @@ class StringTest extends \PHPUnit_Framework_TestCase
     public function testRespectsTheGenerationSize()
     {
         $generationSize = 100;
-        $generator = new String();
+        $generator = new StringGenerator();
         $value = $generator($generationSize);
 
         $this->assertLessThanOrEqual($generationSize, strlen($value));
@@ -32,14 +32,14 @@ class StringTest extends \PHPUnit_Framework_TestCase
 
     public function testShrinksByChoppingOffChars()
     {
-        $generator = new String();
+        $generator = new StringGenerator();
         $lastValue = $generator($size = 10);
         $this->assertSame('abcde', $generator->shrink('abcdef'));
     }
 
     public function testCannotShrinkTheEmptyString()
     {
-        $generator = new String();
+        $generator = new StringGenerator();
         $lastValue = $generator($size = 10);
         $this->assertSame('', $generator->shrink(''));
     }
@@ -70,7 +70,7 @@ class StringTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
     {
-        $generator = new String();
+        $generator = new StringGenerator();
         $generator->shrink(true);
     }
 }


### PR DESCRIPTION
Hi, I renamed `Float` and `String` generators as we discussed in #55. New names are `FloatGenerator` and `StringGenerator`. I ran the tests with this Docker image https://hub.docker.com/_/php/ `php:7.0-cli` and all tests in `test` folder are green.