### PR TITLE
Generator map

### DIFF
--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -17,6 +17,7 @@ class MapTest extends PHPUnit_Framework_TestCase
             )
         )
             ->then(function($tripleOfEvenNumbers) {
+                var_Dump($tripleOfEvenNumbers);
                 foreach ($tripleOfEvenNumbers as $number) {
                     $this->assertTrue(
                         $number % 2 == 0,

--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -1,0 +1,28 @@
+<?php
+use Eris\Generator;
+
+class MapTest extends PHPUnit_Framework_TestCase
+{
+    use Eris\TestTrait;
+
+    public function testApplyingAFunctionToGeneratedValues()
+    {
+        $this->forAll(
+            Generator\vector(
+                3,
+                Generator\map(
+                    function($n) { return $n * 2; },
+                    Generator\nat()
+                )
+            )
+        )
+            ->then(function($tripleOfEvenNumbers) {
+                foreach ($tripleOfEvenNumbers as $number) {
+                    $this->assertTrue(
+                        $number % 2 == 0,
+                        "The element of the vector $number is not even"
+                    );
+                }
+            });
+    }
+}

--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -17,13 +17,50 @@ class MapTest extends PHPUnit_Framework_TestCase
             )
         )
             ->then(function($tripleOfEvenNumbers) {
-                var_Dump($tripleOfEvenNumbers);
                 foreach ($tripleOfEvenNumbers as $number) {
                     $this->assertTrue(
                         $number % 2 == 0,
                         "The element of the vector $number is not even"
                     );
                 }
+            });
+    }
+
+    public function testShrinkingJustMappedValues()
+    {
+        $this->forAll(
+            Generator\map(
+                function($n) { return $n * 2; },
+                Generator\nat()
+            )
+        )
+            ->then(function($evenNumber) {
+                $this->assertLessThanOrEqual(
+                    100,
+                    $evenNumber,
+                    "The number is not less than 100"
+                );
+            });
+    }
+
+    public function testShrinkingMappedValuesInsideOtherGenerators()
+    {
+        $this->forAll(
+            Generator\vector(
+                3,
+                Generator\map(
+                    function($n) { return $n * 2; },
+                    Generator\nat()
+                )
+            )
+        )
+            ->then(function($tripleOfEvenNumbers) {
+                var_dump($tripleOfEvenNumbers);
+                $this->assertLessThanOrEqual(
+                    100,
+                    array_sum($tripleOfEvenNumbers),
+                    "The triple sum " . var_export($tripleOfEvenNumbers, true) . " is not less than 100"
+                );
             });
     }
 }

--- a/src/Eris/Generator.php
+++ b/src/Eris/Generator.php
@@ -24,5 +24,5 @@ interface Generator
      * @param GeneratedValue
      * @return boolean
      */
-    public function contains($element);
+    public function contains(GeneratedValue $element);
 }

--- a/src/Eris/Generator.php
+++ b/src/Eris/Generator.php
@@ -18,7 +18,7 @@ interface Generator
      * @param GeneratedValue<T>
      * @return GeneratedValue<T>
      */
-    public function shrink($element);
+    public function shrink(GeneratedValue $element);
 
     /**
      * @param GeneratedValue

--- a/src/Eris/Generator.php
+++ b/src/Eris/Generator.php
@@ -1,6 +1,8 @@
 <?php
 namespace Eris;
 
+use Eris\Generator\GeneratedValue;
+
 /**
  * Generic interface for a type <T>.
  */
@@ -8,18 +10,18 @@ interface Generator
 {
     /**
      * @params int The generation size
-     * @return T
+     * @return GeneratedValue<T>
      */
     public function __invoke($size);
 
     /**
-     * @param T
-     * @return T
+     * @param GeneratedValue<T>
+     * @return GeneratedValue<T>
      */
     public function shrink($element);
 
     /**
-     * @param mixed
+     * @param GeneratedValue
      * @return boolean
      */
     public function contains($element);

--- a/src/Eris/Generator/BooleanGenerator.php
+++ b/src/Eris/Generator/BooleanGenerator.php
@@ -30,7 +30,7 @@ class BooleanGenerator implements Generator
         return false;
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         return is_bool($element->unbox());
     }

--- a/src/Eris/Generator/BooleanGenerator.php
+++ b/src/Eris/Generator/BooleanGenerator.php
@@ -16,10 +16,10 @@ class BooleanGenerator implements Generator
         $booleanValues = [true, false];
         $randomIndex = rand(0, count($booleanValues) - 1);
 
-        return $booleanValues[$randomIndex];
+        return GeneratedValue::fromJustValue($booleanValues[$randomIndex], 'boolean');
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         if (!$this->contains($element)) {
             throw new DomainException(
@@ -32,6 +32,6 @@ class BooleanGenerator implements Generator
 
     public function contains($element)
     {
-        return is_bool($element);
+        return is_bool($element->unbox());
     }
 }

--- a/src/Eris/Generator/CharacterGenerator.php
+++ b/src/Eris/Generator/CharacterGenerator.php
@@ -61,8 +61,9 @@ class CharacterGenerator implements Generator
         return GeneratedValue::fromJustValue($shrinkedValue, 'character');
     }
 
-    public function contains($value)
+    public function contains(GeneratedValue $generatedValue)
     {
+        $value = $generatedValue->unbox();
         return is_string($value)
             && strlen($value) == 1
             && ord($value) >= $this->lowerLimit

--- a/src/Eris/Generator/CharacterGenerator.php
+++ b/src/Eris/Generator/CharacterGenerator.php
@@ -51,14 +51,14 @@ class CharacterGenerator implements Generator
 
     public function __invoke($_size)
     {
-        return chr(rand($this->lowerLimit, $this->upperLimit));
+        return GeneratedValue::fromJustValue(chr(rand($this->lowerLimit, $this->upperLimit)), 'character');
     }
 
-    public function shrink($value)
+    public function shrink(GeneratedValue $element)
     {
-        $codePoint = ord($value);
-        $shrinkedValue = chr($this->shrinkingProgression->next(ord($value)));
-        return $shrinkedValue;
+        $codePoint = ord($element->unbox());
+        $shrinkedValue = chr($this->shrinkingProgression->next(ord($element->unbox())));
+        return GeneratedValue::fromJustValue($shrinkedValue, 'character');
     }
 
     public function contains($value)

--- a/src/Eris/Generator/ChooseGenerator.php
+++ b/src/Eris/Generator/ChooseGenerator.php
@@ -45,18 +45,18 @@ class ChooseGenerator implements Generator
     {
         $value = rand($this->lowerLimit, $this->upperLimit);
 
-        return $value;
+        return GeneratedValue::fromJustValue($value);
     }
 
     public function shrink($element)
     {
         $this->checkValueToShrink($element);
 
-        if ($element > $this->shrinkTarget) {
-            return $element - 1;
+        if ($element->input() > $this->shrinkTarget) {
+            return GeneratedValue::fromJustValue($element->input() - 1);
         }
-        if ($element < $this->shrinkTarget) {
-            return $element + 1;
+        if ($element->input() < $this->shrinkTarget) {
+            return GeneratedValue::fromJustValue($element->input() + 1);
         }
 
         return $element;
@@ -64,9 +64,9 @@ class ChooseGenerator implements Generator
 
     public function contains($element)
     {
-        return is_int($element)
-            && $element >= $this->lowerLimit
-            && $element <= $this->upperLimit;
+        return is_int($element->input())
+            && $element->input() >= $this->lowerLimit
+            && $element->input() <= $this->upperLimit;
     }
 
     private function checkLimits($lowerLimit, $upperLimit)

--- a/src/Eris/Generator/ChooseGenerator.php
+++ b/src/Eris/Generator/ChooseGenerator.php
@@ -62,7 +62,7 @@ class ChooseGenerator implements Generator
         return $element;
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         // TODO: type hint
         if (!($element instanceof GeneratedValue)) {

--- a/src/Eris/Generator/ChooseGenerator.php
+++ b/src/Eris/Generator/ChooseGenerator.php
@@ -45,7 +45,7 @@ class ChooseGenerator implements Generator
     {
         $value = rand($this->lowerLimit, $this->upperLimit);
 
-        return GeneratedValue::fromJustValue($value);
+        return GeneratedValue::fromJustValue($value, 'choose');
     }
 
     public function shrink(GeneratedValue $element)
@@ -64,6 +64,10 @@ class ChooseGenerator implements Generator
 
     public function contains($element)
     {
+        // TODO: type hint
+        if (!($element instanceof GeneratedValue)) {
+            throw new \InvalidArgumentException();
+        }
         return is_int($element->input())
             && $element->input() >= $this->lowerLimit
             && $element->input() <= $this->upperLimit;

--- a/src/Eris/Generator/ChooseGenerator.php
+++ b/src/Eris/Generator/ChooseGenerator.php
@@ -48,7 +48,7 @@ class ChooseGenerator implements Generator
         return GeneratedValue::fromJustValue($value);
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         $this->checkValueToShrink($element);
 

--- a/src/Eris/Generator/ChooseGenerator.php
+++ b/src/Eris/Generator/ChooseGenerator.php
@@ -64,10 +64,6 @@ class ChooseGenerator implements Generator
 
     public function contains(GeneratedValue $element)
     {
-        // TODO: type hint
-        if (!($element instanceof GeneratedValue)) {
-            throw new \InvalidArgumentException();
-        }
         return is_int($element->input())
             && $element->input() >= $this->lowerLimit
             && $element->input() <= $this->upperLimit;

--- a/src/Eris/Generator/ConstantGenerator.php
+++ b/src/Eris/Generator/ConstantGenerator.php
@@ -36,12 +36,8 @@ class ConstantGenerator implements Generator
         return GeneratedValue::fromJustValue($this->value, 'constant');
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
-        // TODO: substitute with type hint
-        if (!($element instanceof GeneratedValue)) {
-            throw new InvalidArgumentException();
-        }
         return $this->value === $element->input();
     }
 }

--- a/src/Eris/Generator/ConstantGenerator.php
+++ b/src/Eris/Generator/ConstantGenerator.php
@@ -23,7 +23,7 @@ class ConstantGenerator implements Generator
         return GeneratedValue::fromJustValue($this->value, 'constant');
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         if (!$this->contains($element)) {
             throw new DomainException(

--- a/src/Eris/Generator/ConstantGenerator.php
+++ b/src/Eris/Generator/ConstantGenerator.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 use DomainException;
+use InvalidArgumentException;
 
 class ConstantGenerator implements Generator
 {
@@ -37,6 +38,10 @@ class ConstantGenerator implements Generator
 
     public function contains($element)
     {
+        // TODO: substitute with type hint
+        if (!($element instanceof GeneratedValue)) {
+            throw new InvalidArgumentException();
+        }
         return $this->value === $element->input();
     }
 }

--- a/src/Eris/Generator/ConstantGenerator.php
+++ b/src/Eris/Generator/ConstantGenerator.php
@@ -20,7 +20,7 @@ class ConstantGenerator implements Generator
 
     public function __invoke($_size)
     {
-        return $this->value;
+        return GeneratedValue::fromJustValue($this->value);
     }
 
     public function shrink($element)
@@ -32,11 +32,11 @@ class ConstantGenerator implements Generator
             );
         }
 
-        return $this->value;
+        return GeneratedValue::fromJustValue($this->value, 'constant');
     }
 
     public function contains($element)
     {
-        return $this->value === $element;
+        return $this->value === $element->input();
     }
 }

--- a/src/Eris/Generator/ConstantGenerator.php
+++ b/src/Eris/Generator/ConstantGenerator.php
@@ -20,7 +20,7 @@ class ConstantGenerator implements Generator
 
     public function __invoke($_size)
     {
-        return GeneratedValue::fromJustValue($this->value);
+        return GeneratedValue::fromJustValue($this->value, 'constant');
     }
 
     public function shrink($element)

--- a/src/Eris/Generator/DateGenerator.php
+++ b/src/Eris/Generator/DateGenerator.php
@@ -44,23 +44,30 @@ class DateGenerator implements Generator
     public function __invoke($_size)
     {
         $generatedOffset = rand(0, $this->intervalInSeconds);
-        return $this->fromOffset($generatedOffset);
+        return GeneratedValue::fromJustValue(
+            $this->fromOffset($generatedOffset),
+            'date'
+        );
     }
 
     public function shrink(GeneratedValue $element)
     {
         $this->ensureIsInDomain($element);
 
-        $timeOffset = $element->getTimestamp() - $this->lowerLimit->getTimestamp();
+        $timeOffset = $element->unbox()->getTimestamp() - $this->lowerLimit->getTimestamp();
         $halvedOffset = floor($timeOffset / 2);
-        return $this->fromOffset($halvedOffset);
+        return GeneratedValue::fromJustValue(
+            $this->fromOffset($halvedOffset),
+            'date'
+        );
     }
 
     public function contains($element)
     {
-        return $element instanceof DateTime
-            && $element >= $this->lowerLimit
-            && $element <= $this->upperLimit;
+        $value = $element->unbox();
+        return $value instanceof DateTime
+            && $value >= $this->lowerLimit
+            && $value <= $this->upperLimit;
     }
 
     /**

--- a/src/Eris/Generator/DateGenerator.php
+++ b/src/Eris/Generator/DateGenerator.php
@@ -62,7 +62,7 @@ class DateGenerator implements Generator
         );
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         $value = $element->unbox();
         return $value instanceof DateTime

--- a/src/Eris/Generator/DateGenerator.php
+++ b/src/Eris/Generator/DateGenerator.php
@@ -47,7 +47,7 @@ class DateGenerator implements Generator
         return $this->fromOffset($generatedOffset);
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         $this->ensureIsInDomain($element);
 

--- a/src/Eris/Generator/ElementsGenerator.php
+++ b/src/Eris/Generator/ElementsGenerator.php
@@ -32,7 +32,7 @@ class ElementsGenerator implements Generator
     public function __invoke($_size)
     {
         $index = rand(0, count($this->domain) - 1);
-        return $this->domain[$index];
+        return GeneratedValue::fromJustValue($this->domain[$index], 'elements');
     }
 
     public function shrink(GeneratedValue $element)

--- a/src/Eris/Generator/ElementsGenerator.php
+++ b/src/Eris/Generator/ElementsGenerator.php
@@ -49,6 +49,6 @@ class ElementsGenerator implements Generator
 
     public function contains($element)
     {
-        return in_array($element, $this->domain);
+        return in_array($element->unbox(), $this->domain);
     }
 }

--- a/src/Eris/Generator/ElementsGenerator.php
+++ b/src/Eris/Generator/ElementsGenerator.php
@@ -47,7 +47,7 @@ class ElementsGenerator implements Generator
         return $element;
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         return in_array($element->unbox(), $this->domain);
     }

--- a/src/Eris/Generator/ElementsGenerator.php
+++ b/src/Eris/Generator/ElementsGenerator.php
@@ -35,7 +35,7 @@ class ElementsGenerator implements Generator
         return $this->domain[$index];
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         if (!$this->contains($element)) {
             throw new DomainException(

--- a/src/Eris/Generator/FloatGenerator.php
+++ b/src/Eris/Generator/FloatGenerator.php
@@ -24,7 +24,7 @@ class FloatGenerator implements Generator
                           : $value * (-1);
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         if (!$this->contains($element)) {
             throw new DomainException(

--- a/src/Eris/Generator/FloatGenerator.php
+++ b/src/Eris/Generator/FloatGenerator.php
@@ -44,7 +44,7 @@ class FloatGenerator implements Generator
         return GeneratedValue::fromJustValue(0.0, 'float');
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         return is_float($element->unbox());
     }

--- a/src/Eris/Generator/FloatGenerator.php
+++ b/src/Eris/Generator/FloatGenerator.php
@@ -19,31 +19,33 @@ class FloatGenerator implements Generator
     {
         $value = (float) rand(0, $size) / (float) rand(1, $size);
 
-        return rand(0, 1) === 0
-                          ? $value
-                          : $value * (-1);
+        $signedValue = rand(0, 1) === 0
+            ? $value
+            : $value * (-1);
+        return GeneratedValue::fromJustValue($signedValue, 'float');
     }
 
     public function shrink(GeneratedValue $element)
     {
+        $value = $element->unbox();
         if (!$this->contains($element)) {
             throw new DomainException(
-                'Cannot shrink ' . $element . ' because it does not belong ' .
+                'Cannot shrink ' . $value . ' because it does not belong ' .
                 'to the domain of Floats'
             );
         }
 
-        if ($element < 0.0) {
-            return min($element + 1.0, 0.0);
+        if ($value < 0.0) {
+            return GeneratedValue::fromJustValue(min($value + 1.0, 0.0), 'float');
         }
-        if ($element > 0.0) {
-            return max($element - 1.0, 0.0);
+        if ($value > 0.0) {
+            return GeneratedValue::fromJustValue(max($value - 1.0, 0.0), 'float');
         }
-        return 0.0;
+        return GeneratedValue::fromJustValue(0.0, 'float');
     }
 
     public function contains($element)
     {
-        return is_float($element);
+        return is_float($element->unbox());
     }
 }

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -67,7 +67,7 @@ class FrequencyGenerator implements Generator
         )->annotate('original_generator', $originalGeneratorIndex);
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         foreach ($this->generators as $generator) {
             if ($generator['generator']->contains($element->input())) {

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -43,12 +43,9 @@ class FrequencyGenerator implements Generator
     {
         list ($index, $generator) = $this->pickFrom($this->generators);
         $originalValue = $generator->__invoke($size);
-        return GeneratedValue::fromValueAndInput(
-            // TODO: extract this operation as GeneratedValue::annotate
-            $originalValue->unbox(),
-            $originalValue,
-            'frequency'
-        )->annotate('original_generator', $index);
+        return $originalValue
+            ->derivedIn('frequency')
+            ->annotate('original_generator', $index);
     }
 
     public function shrink(GeneratedValue $element)
@@ -60,11 +57,10 @@ class FrequencyGenerator implements Generator
         }
         $originalGeneratorIndex = $element->annotation('original_generator');
         $shrinkedValue = $this->generators[$originalGeneratorIndex]['generator']->shrink($element->input());
-        return GeneratedValue::fromValueAndInput(
-            $shrinkedValue->unbox(),
-            $shrinkedValue,
-            'frequency'
-        )->annotate('original_generator', $originalGeneratorIndex);
+
+        return $shrinkedValue
+            ->derivedIn('frequency')
+            ->annotate('original_generator', $originalGeneratorIndex);
     }
 
     public function contains(GeneratedValue $element)

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -43,9 +43,14 @@ class FrequencyGenerator implements Generator
     {
         list ($index, $generator) = $this->pickFrom($this->generators);
         $originalValue = $generator->__invoke($size);
-        return $originalValue
-            ->derivedIn('frequency')
-            ->annotate('original_generator', $index);
+        return GeneratedValue::fromValueAndInput(
+            $originalValue->unbox(),
+            [
+                'value' => $originalValue,
+                'generator' => $index,
+            ],
+            'frequency'
+        );
     }
 
     public function shrink(GeneratedValue $element)
@@ -55,18 +60,25 @@ class FrequencyGenerator implements Generator
                 var_export($element, true) . ' is not in one of the given domains'
             );
         }
-        $originalGeneratorIndex = $element->annotation('original_generator');
-        $shrinkedValue = $this->generators[$originalGeneratorIndex]['generator']->shrink($element->input());
+        $input = $element->input();
+        $originalGeneratorIndex = $input['generator'];
+        $shrinkedValue = $this->generators[$originalGeneratorIndex]['generator']->shrink($input['value']);
 
-        return $shrinkedValue
-            ->derivedIn('frequency')
-            ->annotate('original_generator', $originalGeneratorIndex);
+        return GeneratedValue::fromValueAndInput(
+            $shrinkedValue->unbox(),
+            [
+                'value' => $shrinkedValue,
+                'generator' => $originalGeneratorIndex,
+            ],
+            'frequency'
+        );
     }
 
     public function contains(GeneratedValue $element)
     {
-        $originalGeneratorIndex = $element->annotation('original_generator');
-        return $this->generators[$originalGeneratorIndex]['generator']->contains($element->input());
+        $input = $element->input();
+        $originalGeneratorIndex = $input['generator'];
+        return $this->generators[$originalGeneratorIndex]['generator']->contains($input['value']);
     }
 
     /**

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -51,7 +51,7 @@ class FrequencyGenerator implements Generator
         )->annotate('original_generator', $index);
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         if (!$this->contains($element)) {
             throw new DomainException(

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -65,22 +65,8 @@ class FrequencyGenerator implements Generator
 
     public function contains(GeneratedValue $element)
     {
-        foreach ($this->generators as $generator) {
-            if ($generator['generator']->contains($element->input())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private function allGeneratorsAbleToShrink($element)
-    {
-        return array_filter(
-            $this->generators,
-            function($generator) use ($element) {
-                return $generator['generator']->contains($element);
-            }
-        );
+        $originalGeneratorIndex = $element->annotation('original_generator');
+        return $this->generators[$originalGeneratorIndex]['generator']->contains($element->input());
     }
 
     /**

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -16,4 +16,9 @@ class GeneratedValue
         $this->value = $value;
         $this->input = $input;
     }
+
+    public function unbox()
+    {
+        return $this->value;
+    }
 }

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -4,17 +4,37 @@ namespace Eris\Generator;
 use Eris\Generator\GeneratedValue;
 use InvalidArgumentException;
 
+/**
+ * Parametric with respect to the type <T> of its value.
+ * Immutable object, modifiers return a new GeneratedValue instance.
+ */
 final class GeneratedValue
 {
     private $value;
     private $input;
     private $generatorName;
     
+    /**
+     * A value and the input that was used to derive it.
+     * The input usually comes from another Generator.
+     *
+     * @param T $value
+     * @param GeneratedValue|mixed $input
+     * @param string $generatorName  'tuple'
+     * @return GeneratedValue
+     */
     public static function fromValueAndInput($value, $input, $generatorName = null)
     {
         return new self($value, $input, $generatorName);
     }
 
+    /**
+     * Input will be copied from value.
+     *
+     * @param T $value
+     * @param string $generatorName  'tuple'
+     * @return GeneratedValue
+     */
     public static function fromJustValue($value, $generatorName = null)
     {
         return new self($value, $value, $generatorName);
@@ -31,11 +51,17 @@ final class GeneratedValue
         $this->annotations = $annotations;
     }
 
+    /**
+     * @return GeneratedValue|mixed
+     */
     public function input()
     {
         return $this->input;
     }
 
+    /**
+     * @return T
+     */
     public function unbox()
     {
         return $this->value;
@@ -46,6 +72,9 @@ final class GeneratedValue
         return var_export($this, true);
     }
 
+    /**
+     * @return GeneratedValue
+     */
     public function map(callable $applyToValue, $generatorName)
     {
         return new self(
@@ -55,6 +84,10 @@ final class GeneratedValue
         );
     }
 
+    /**
+     * @param string $generatorName  'tuple', 'vector'
+     * @return GeneratedValue
+     */
     public function derivedIn($generatorName)
     {
         return $this->map(
@@ -63,6 +96,11 @@ final class GeneratedValue
         );
     }
 
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @return GeneratedValue
+     */
     public function annotate($key, $value)
     {
         $annotations = $this->annotations;
@@ -76,7 +114,8 @@ final class GeneratedValue
     }
 
     /**
-     * TODO: docblock, validation
+     * @param string $key
+     * @return mixed
      */
     public function annotation($key)
     {

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -1,24 +1,50 @@
 <?php
 namespace Eris\Generator;
 
-class GeneratedValue
+use Eris\Generator\GeneratedValue;
+use InvalidArgumentException;
+
+final class GeneratedValue
 {
     private $value;
     private $input;
+    private $generatorName;
     
-    public static function fromValueAndInput($value, $input)
+    public static function fromValueAndInput($value, $input, $generatorName = null)
     {
-        return new self($value, $input);
+        if ($value instanceof self) {
+            throw new InvalidArgumentException("It looks like you are trying to build a GeneratedValue whose value is another GeneratedValue. This is almost always an error as values will be passed as-is to properties and GeneratedValue should be hidden from them.");
+        }
+        return new self($value, $input, $generatorName);
+    }
+
+    public static function fromJustValue($value, $generatorName = null)
+    {
+        return new self($value, $value, $generatorName);
     }
     
-    private function __construct($value, $input)
+    private function __construct($value, $input, $generatorName)
     {
+        if ($value instanceof self) {
+            throw new InvalidArgumentException("It looks like you are trying to build a GeneratedValue whose value is another GeneratedValue. This is almost always an error as values will be passed as-is to properties and GeneratedValue should be hidden from them.");
+        }
         $this->value = $value;
         $this->input = $input;
+        $this->generatorName = $generatorName;
+    }
+
+    public function input()
+    {
+        return $this->input;
     }
 
     public function unbox()
     {
         return $this->value;
+    }
+
+    public function __toString()
+    {
+        return var_export($this, true);
     }
 }

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -12,9 +12,6 @@ final class GeneratedValue
     
     public static function fromValueAndInput($value, $input, $generatorName = null)
     {
-        if ($value instanceof self) {
-            throw new InvalidArgumentException("It looks like you are trying to build a GeneratedValue whose value is another GeneratedValue. This is almost always an error as values will be passed as-is to properties and GeneratedValue should be hidden from them.");
-        }
         return new self($value, $input, $generatorName);
     }
 

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -55,6 +55,14 @@ final class GeneratedValue
         );
     }
 
+    public function derivedIn($generatorName)
+    {
+        return $this->map(
+            function($value) { return $value; },
+            $generatorName
+        );
+    }
+
     public function annotate($key, $value)
     {
         $annotations = $this->annotations;

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -1,0 +1,19 @@
+<?php
+namespace Eris\Generator;
+
+class GeneratedValue
+{
+    private $value;
+    private $input;
+    
+    public static function fromValueAndInput($value, $input)
+    {
+        return new self($value, $input);
+    }
+    
+    private function __construct($value, $input)
+    {
+        $this->value = $value;
+        $this->input = $input;
+    }
+}

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -23,7 +23,7 @@ final class GeneratedValue
         return new self($value, $value, $generatorName);
     }
     
-    private function __construct($value, $input, $generatorName)
+    private function __construct($value, $input, $generatorName, array $annotations = [])
     {
         if ($value instanceof self) {
             throw new InvalidArgumentException("It looks like you are trying to build a GeneratedValue whose value is another GeneratedValue. This is almost always an error as values will be passed as-is to properties and GeneratedValue should be hidden from them.");
@@ -31,6 +31,7 @@ final class GeneratedValue
         $this->value = $value;
         $this->input = $input;
         $this->generatorName = $generatorName;
+        $this->annotations = $annotations;
     }
 
     public function input()
@@ -46,5 +47,25 @@ final class GeneratedValue
     public function __toString()
     {
         return var_export($this, true);
+    }
+
+    public function annotate($key, $value)
+    {
+        $annotations = $this->annotations;
+        $annotations[$key] = $value;
+        return new self(
+            $this->value,
+            $this->input,
+            $this->generatorName,
+            $annotations
+        );
+    }
+
+    /**
+     * TODO: docblock, validation
+     */
+    public function annotation($key)
+    {
+        return $this->annotations[$key];
     }
 }

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -49,6 +49,15 @@ final class GeneratedValue
         return var_export($this, true);
     }
 
+    public function map(callable $applyToValue, $generatorName)
+    {
+        return new self(
+            $applyToValue($this->value),
+            $this,
+            $generatorName
+        );
+    }
+
     public function annotate($key, $value)
     {
         $annotations = $this->annotations;

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -95,30 +95,4 @@ final class GeneratedValue
             $generatorName
         );
     }
-
-    /**
-     * @param string $key
-     * @param mixed $value
-     * @return GeneratedValue
-     */
-    public function annotate($key, $value)
-    {
-        $annotations = $this->annotations;
-        $annotations[$key] = $value;
-        return new self(
-            $this->value,
-            $this->input,
-            $this->generatorName,
-            $annotations
-        );
-    }
-
-    /**
-     * @param string $key
-     * @return mixed
-     */
-    public function annotation($key)
-    {
-        return $this->annotations[$key];
-    }
 }

--- a/src/Eris/Generator/IntegerGenerator.php
+++ b/src/Eris/Generator/IntegerGenerator.php
@@ -90,28 +90,31 @@ class IntegerGenerator implements Generator
         $value = rand(0, $size);
         $mapFn = $this->mapFn;
 
-        return rand(0, 1) === 0
+        $result = rand(0, 1) === 0
                           ? $mapFn($value)
                           : $mapFn($value * (-1));
+        return GeneratedValue::fromValueAndInput($result, $result);
     }
 
     public function shrink($element)
     {
         $this->checkValueToShrink($element);
+        $element = $element->input();
 
+        // TODO: GeneratedValue::apply(function($input) {}) : GeneratedValue
         if ($element > 0) {
-            return $element - 1;
+            return GeneratedValue::fromJustValue($element - 1);
         }
         if ($element < 0) {
-            return $element + 1;
+            return GeneratedValue::fromJustValue($element + 1);
         }
 
-        return $element;
+        return GeneratedValue::fromJustValue($element, $element);
     }
 
     public function contains($element)
     {
-        return is_int($element);
+        return is_int($element->input());
     }
 
     private function checkValueToShrink($value)

--- a/src/Eris/Generator/IntegerGenerator.php
+++ b/src/Eris/Generator/IntegerGenerator.php
@@ -96,7 +96,7 @@ class IntegerGenerator implements Generator
         return GeneratedValue::fromValueAndInput($result, $result);
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         $this->checkValueToShrink($element);
         $element = $element->input();

--- a/src/Eris/Generator/IntegerGenerator.php
+++ b/src/Eris/Generator/IntegerGenerator.php
@@ -112,7 +112,7 @@ class IntegerGenerator implements Generator
         return GeneratedValue::fromJustValue($element, $element);
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         return is_int($element->input());
     }

--- a/src/Eris/Generator/IntegerGenerator.php
+++ b/src/Eris/Generator/IntegerGenerator.php
@@ -93,7 +93,10 @@ class IntegerGenerator implements Generator
         $result = rand(0, 1) === 0
                           ? $mapFn($value)
                           : $mapFn($value * (-1));
-        return GeneratedValue::fromValueAndInput($result, $result);
+        return GeneratedValue::fromJustValue(
+            $result,
+            'integer'
+        );
     }
 
     public function shrink(GeneratedValue $element)
@@ -101,15 +104,14 @@ class IntegerGenerator implements Generator
         $this->checkValueToShrink($element);
         $element = $element->input();
 
-        // TODO: GeneratedValue::apply(function($input) {}) : GeneratedValue
         if ($element > 0) {
-            return GeneratedValue::fromJustValue($element - 1);
+            return GeneratedValue::fromJustValue($element - 1, 'integer');
         }
         if ($element < 0) {
-            return GeneratedValue::fromJustValue($element + 1);
+            return GeneratedValue::fromJustValue($element + 1, 'integer');
         }
 
-        return GeneratedValue::fromJustValue($element, $element);
+        return GeneratedValue::fromJustValue($element, 'integer');
     }
 
     public function contains(GeneratedValue $element)

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -4,7 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 
 // TODO: support calls like ($function . $generator)
-// TODO: $function vs $map, choose a name (look at test.check)
 function map(callable $function, Generator $generator)
 {
     return new MapGenerator($function, $generator);

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -32,11 +32,8 @@ class MapGenerator implements Generator
         );
     }
 
-    public function shrink(/*GeneratedValue*/ $value)
+    public function shrink(GeneratedValue $value)
     {
-        if (!($value instanceof GeneratedValue)) {
-            throw new \Exception("Value to be shrunk must be a GeneratedValue, not " . var_export($value, true));
-        }
         $input = $value->input();
         $shrunkInput = $this->generator->shrink($input);
         return GeneratedValue::fromValueAndInput(

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -3,6 +3,13 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 
+// TODO: support calls like ($function . $generator)
+// TODO: $function vs $map, choose a name (look at test.check)
+function map(callable $function, Generator $generator)
+{
+    return new MapGenerator($function, $generator);
+}
+
 class MapGenerator implements Generator
 {
     private $map;

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -1,0 +1,36 @@
+<?php
+namespace Eris\Generator;
+
+use Eris\Generator;
+
+class MapGenerator implements Generator
+{
+    private $map;
+    private $generator;
+    
+    public function __construct($map, $generator)
+    {
+        $this->map = $map;
+        $this->generator = $generator;
+    }
+
+    public function __invoke($_size)
+    {
+        $input = $this->generator->__invoke($_size);
+        $value = call_user_func($this->map, $input);
+        return GeneratedValue::fromValueAndInput(
+            $value,
+            $input
+        );
+    }
+
+    public function shrink($value)
+    {
+        throw new \BadMethodCallException("Not implemented yet");
+    }
+
+    public function contains($value)
+    {
+        throw new \BadMethodCallException("Not implemented yet");
+    }
+}

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -24,20 +24,36 @@ class MapGenerator implements Generator
     public function __invoke($_size)
     {
         $input = $this->generator->__invoke($_size);
-        $value = call_user_func($this->map, $input);
+        $value = $this->apply($input);
         return GeneratedValue::fromValueAndInput(
             $value,
-            $input
+            $input,
+            'map'
         );
     }
 
-    public function shrink($value)
+    public function shrink(/*GeneratedValue*/ $value)
     {
-        throw new \BadMethodCallException("Not implemented yet");
+        if (!($value instanceof GeneratedValue)) {
+            throw new \Exception("Value to be shrunk must be a GeneratedValue, not " . var_export($value, true));
+        }
+        $input = $value->input();
+        $shrunkInput = $this->generator->shrink($input);
+        return GeneratedValue::fromValueAndInput(
+            $this->apply($shrunkInput),
+            $shrunkInput,
+            'map'
+        );
+    }
+
+    private function apply(GeneratedValue $input)
+    {
+        return call_user_func($this->map, $input->unbox());
     }
 
     public function contains($value)
     {
-        throw new \BadMethodCallException("Not implemented yet");
+        $input = $value->input();
+        return $this->generator->contains($input);
     }
 }

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -15,7 +15,7 @@ class MapGenerator implements Generator
     private $map;
     private $generator;
     
-    public function __construct($map, $generator)
+    public function __construct(callable $map, $generator)
     {
         $this->map = $map;
         $this->generator = $generator;
@@ -24,10 +24,8 @@ class MapGenerator implements Generator
     public function __invoke($_size)
     {
         $input = $this->generator->__invoke($_size);
-        $value = $this->apply($input);
-        return GeneratedValue::fromValueAndInput(
-            $value,
-            $input,
+        return $input->map(
+            $this->map,
             'map'
         );
     }
@@ -36,21 +34,14 @@ class MapGenerator implements Generator
     {
         $input = $value->input();
         $shrunkInput = $this->generator->shrink($input);
-        return GeneratedValue::fromValueAndInput(
-            $this->apply($shrunkInput),
-            $shrunkInput,
+        return $shrunkInput->map(
+            $this->map,
             'map'
         );
     }
 
-    private function apply(GeneratedValue $input)
-    {
-        return call_user_func($this->map, $input->unbox());
-    }
-
     public function contains(GeneratedValue $value)
     {
-        $input = $value->input();
-        return $this->generator->contains($input);
+        return $this->generator->contains($value->input());
     }
 }

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -48,7 +48,7 @@ class MapGenerator implements Generator
         return call_user_func($this->map, $input->unbox());
     }
 
-    public function contains($value)
+    public function contains(GeneratedValue $value)
     {
         $input = $value->input();
         return $this->generator->contains($input);

--- a/src/Eris/Generator/NamesGenerator.php
+++ b/src/Eris/Generator/NamesGenerator.php
@@ -41,25 +41,25 @@ class NamesGenerator implements Generator
             return '';
         }
         $index = rand(0, count($candidateNames) - 1);
-        return $candidateNames[$index];
+        return GeneratedValue::fromJustValue($candidateNames[$index], 'names');
     }
 
     public function shrink(GeneratedValue $value)
     {
         $candidateNames = $this->filterDataSet(
-            $this->lengthSlightlyLessThan(strlen($value))
+            $this->lengthSlightlyLessThan(strlen($value->unbox()))
         );
 
         if (!$candidateNames) {
             return $value;
         }
-        $distances = $this->distancesBy($value, $candidateNames);
-        return $this->minimumDistanceName($distances);
+        $distances = $this->distancesBy($value->unbox(), $candidateNames);
+        return GeneratedValue::fromJustValue($this->minimumDistanceName($distances), 'names');
     }
 
     public function contains($value)
     {
-        return in_array($value, $this->list);
+        return in_array($value->unbox(), $this->list);
     }
 
     private function filterDataSet(callable $predicate)

--- a/src/Eris/Generator/NamesGenerator.php
+++ b/src/Eris/Generator/NamesGenerator.php
@@ -38,7 +38,7 @@ class NamesGenerator implements Generator
             $this->lengthLessThanOrEqualTo($size)
         );
         if (!$candidateNames) {
-            return '';
+            return GeneratedValue::fromJustValue('', 'names');
         }
         $index = rand(0, count($candidateNames) - 1);
         return GeneratedValue::fromJustValue($candidateNames[$index], 'names');

--- a/src/Eris/Generator/NamesGenerator.php
+++ b/src/Eris/Generator/NamesGenerator.php
@@ -57,7 +57,7 @@ class NamesGenerator implements Generator
         return GeneratedValue::fromJustValue($this->minimumDistanceName($distances), 'names');
     }
 
-    public function contains($value)
+    public function contains(GeneratedValue $value)
     {
         return in_array($value->unbox(), $this->list);
     }

--- a/src/Eris/Generator/NamesGenerator.php
+++ b/src/Eris/Generator/NamesGenerator.php
@@ -44,7 +44,7 @@ class NamesGenerator implements Generator
         return $candidateNames[$index];
     }
 
-    public function shrink($value)
+    public function shrink(GeneratedValue $value)
     {
         $candidateNames = $this->filterDataSet(
             $this->lengthSlightlyLessThan(strlen($value))

--- a/src/Eris/Generator/OneOfGenerator.php
+++ b/src/Eris/Generator/OneOfGenerator.php
@@ -23,7 +23,7 @@ class OneOfGenerator implements Generator
 
     public function shrink(GeneratedValue $element)
     {
-        return $this->generator->shrink(GeneratedValue $element);
+        return $this->generator->shrink($element);
     }
 
     public function contains($element)

--- a/src/Eris/Generator/OneOfGenerator.php
+++ b/src/Eris/Generator/OneOfGenerator.php
@@ -21,9 +21,9 @@ class OneOfGenerator implements Generator
         return $this->generator->__invoke($size);
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
-        return $this->generator->shrink($element);
+        return $this->generator->shrink(GeneratedValue $element);
     }
 
     public function contains($element)

--- a/src/Eris/Generator/OneOfGenerator.php
+++ b/src/Eris/Generator/OneOfGenerator.php
@@ -26,7 +26,7 @@ class OneOfGenerator implements Generator
         return $this->generator->shrink($element);
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         return $this->generator->contains($element);
     }

--- a/src/Eris/Generator/RegexGenerator.php
+++ b/src/Eris/Generator/RegexGenerator.php
@@ -50,9 +50,9 @@ class RegexGenerator implements Generator
         return $value;
     }
 
-    public function contains($value)
+    public function contains(GeneratedValue $value)
     {
-        return is_string($value)
-            && (bool) preg_match("/{$this->expression}/", $value);
+        return is_string($value->unbox())
+            && (bool) preg_match("/{$this->expression}/", $value->unbox());
     }
 }

--- a/src/Eris/Generator/RegexGenerator.php
+++ b/src/Eris/Generator/RegexGenerator.php
@@ -42,7 +42,7 @@ class RegexGenerator implements Generator
         $parser = new Parser($lexer,new Scope(),new Scope());
         $parser->parse()->getResult()->generate($result,$gen);
 
-        return $result;
+        return GeneratedValue::fromJustValue($result, 'regex');
     }
 
     public function shrink(GeneratedValue $value)

--- a/src/Eris/Generator/RegexGenerator.php
+++ b/src/Eris/Generator/RegexGenerator.php
@@ -45,7 +45,7 @@ class RegexGenerator implements Generator
         return $result;
     }
 
-    public function shrink($value)
+    public function shrink(GeneratedValue $value)
     {
         return $value;
     }

--- a/src/Eris/Generator/SequenceGenerator.php
+++ b/src/Eris/Generator/SequenceGenerator.php
@@ -46,7 +46,7 @@ class SequenceGenerator implements Generator
         }
     }
 
-    public function contains($sequence)
+    public function contains(GeneratedValue $sequence)
     {
         return $this->vector(count($sequence->unbox()))->contains($sequence);
     }

--- a/src/Eris/Generator/SetGenerator.php
+++ b/src/Eris/Generator/SetGenerator.php
@@ -71,7 +71,7 @@ class SetGenerator implements Generator
         );
     }
 
-    public function contains($set)
+    public function contains(GeneratedValue $set)
     {
         foreach ($set->input() as $element) {
             if (!$this->singleElementGenerator->contains($element)) {

--- a/src/Eris/Generator/StringGenerator.php
+++ b/src/Eris/Generator/StringGenerator.php
@@ -11,10 +11,6 @@ function string()
 
 class StringGenerator implements Generator
 {
-    public function __construct()
-    {
-    }
-
     public function __invoke($size)
     {
         $length = rand(0, $size);
@@ -23,7 +19,7 @@ class StringGenerator implements Generator
         for ($i = 0; $i < $length; $i++) {
             $built .= chr(rand(33, 126));
         }
-        return $built;
+        return GeneratedValue::fromJustValue($built, 'string');
     }
 
     public function shrink(GeneratedValue $element)
@@ -35,14 +31,17 @@ class StringGenerator implements Generator
             );
         }
 
-        if ($element === '') {
-            return '';
+        if ($element->unbox() === '') {
+            return $element;
         }
-        return substr($element, 0, -1);
+        return GeneratedValue::fromJustValue(
+            substr($element->unbox(), 0, -1),
+            'string'
+        );
     }
 
     public function contains($element)
     {
-        return is_string($element);
+        return is_string($element->unbox());
     }
 }

--- a/src/Eris/Generator/StringGenerator.php
+++ b/src/Eris/Generator/StringGenerator.php
@@ -26,7 +26,7 @@ class StringGenerator implements Generator
         return $built;
     }
 
-    public function shrink($element)
+    public function shrink(GeneratedValue $element)
     {
         if (!$this->contains($element)) {
             throw new DomainException(

--- a/src/Eris/Generator/StringGenerator.php
+++ b/src/Eris/Generator/StringGenerator.php
@@ -40,7 +40,7 @@ class StringGenerator implements Generator
         );
     }
 
-    public function contains($element)
+    public function contains(GeneratedValue $element)
     {
         return is_string($element->unbox());
     }

--- a/src/Eris/Generator/SubsetGenerator.php
+++ b/src/Eris/Generator/SubsetGenerator.php
@@ -64,7 +64,7 @@ class SubsetGenerator implements Generator
         );
     }
 
-    public function contains($set)
+    public function contains(GeneratedValue $set)
     {
         foreach ($set->input() as $element) {
             if (!in_array($element, $this->universe)) {

--- a/src/Eris/Generator/SubsetGenerator.php
+++ b/src/Eris/Generator/SubsetGenerator.php
@@ -38,10 +38,10 @@ class SubsetGenerator implements Generator
             } 
         }
 
-        return $subset;
+        return GeneratedValue::fromJustValue($subset, 'subset');
     }
 
-    public function shrink($set)
+    public function shrink(GeneratedValue $set)
     {
         // TODO: see SetGenerator::shrink()
         if (!$this->contains($set)) {
@@ -51,18 +51,22 @@ class SubsetGenerator implements Generator
             );
         }
 
-        if (count($set) === 0) {
+        if (count($set->unbox()) === 0) {
             return $set;
         }
 
-        $indexOfElementToRemove = array_rand($set);
-        unset($set[$indexOfElementToRemove]);
-        return array_values($set);
+        $input = $set->input();
+        $indexOfElementToRemove = array_rand($input);
+        unset($input[$indexOfElementToRemove]);
+        return GeneratedValue::fromJustValue(
+            array_values($input),
+            'subset'
+        );
     }
 
     public function contains($set)
     {
-        foreach ($set as $element) {
+        foreach ($set->input() as $element) {
             if (!in_array($element, $this->universe)) {
                 return false;
             }

--- a/src/Eris/Generator/TupleGenerator.php
+++ b/src/Eris/Generator/TupleGenerator.php
@@ -35,11 +35,20 @@ class TupleGenerator implements Generator
 
     public function __invoke($size)
     {
-        return array_map(
+        $input = array_map(
             function($generator) use ($size) {
                 return $generator($size);
             },
             $this->generators
+        );
+        return GeneratedValue::fromValueAndInput(
+            array_map(
+                function($value) {
+                    return $value->unbox();
+                },
+                $input
+            ),
+            $input
         );
     }
 

--- a/src/Eris/Generator/TupleGenerator.php
+++ b/src/Eris/Generator/TupleGenerator.php
@@ -57,7 +57,7 @@ class TupleGenerator implements Generator
 
     public function shrink(GeneratedValue $tuple)
     {
-        // TODO: GeneratedValue in signature of shrink() and contains()
+        // TODO: GeneratedValue in signature of shrink() and contains(GeneratedValue )
         if (!($tuple instanceof GeneratedValue)) {
             throw new \Exception("Value to be shrunk must be a GeneratedValue, not " . var_export($tuple, true));
         }
@@ -92,7 +92,7 @@ class TupleGenerator implements Generator
         );
     }
 
-    public function contains($tuple)
+    public function contains(GeneratedValue $tuple)
     {
         if (!($tuple instanceof GeneratedValue)) {
             throw new \Exception("Value to be shrunk must be a GeneratedValue, not " . var_export($tuple, true));

--- a/src/Eris/Generator/TupleGenerator.php
+++ b/src/Eris/Generator/TupleGenerator.php
@@ -57,10 +57,6 @@ class TupleGenerator implements Generator
 
     public function shrink(GeneratedValue $tuple)
     {
-        // TODO: GeneratedValue in signature of shrink() and contains(GeneratedValue )
-        if (!($tuple instanceof GeneratedValue)) {
-            throw new \Exception("Value to be shrunk must be a GeneratedValue, not " . var_export($tuple, true));
-        }
         $this->checkValueToShrink($tuple);
         $input = $tuple->input();
 
@@ -94,9 +90,6 @@ class TupleGenerator implements Generator
 
     public function contains(GeneratedValue $tuple)
     {
-        if (!($tuple instanceof GeneratedValue)) {
-            throw new \Exception("Value to be shrunk must be a GeneratedValue, not " . var_export($tuple, true));
-        }
         $input = $tuple->input();
         if (!is_array($input)) {
             throw new \Exception("Input must be an array, not " . var_export($input, true));

--- a/src/Eris/Generator/TupleGenerator.php
+++ b/src/Eris/Generator/TupleGenerator.php
@@ -55,7 +55,7 @@ class TupleGenerator implements Generator
         );
     }
 
-    public function shrink($tuple)
+    public function shrink(GeneratedValue $tuple)
     {
         // TODO: GeneratedValue in signature of shrink() and contains()
         if (!($tuple instanceof GeneratedValue)) {

--- a/src/Eris/Generator/VectorGenerator.php
+++ b/src/Eris/Generator/VectorGenerator.php
@@ -41,7 +41,7 @@ class VectorGenerator implements Generator
         return $this->generator->shrink($vector);
     }
 
-    public function contains($vector)
+    public function contains(GeneratedValue $vector)
     {
         return $this->generator->contains($vector);
     }

--- a/src/Eris/Generator/VectorGenerator.php
+++ b/src/Eris/Generator/VectorGenerator.php
@@ -29,7 +29,7 @@ class VectorGenerator implements Generator
         return $this->generator->__invoke($size);
     }
 
-    public function shrink($vector)
+    public function shrink(GeneratedValue $vector)
     {
         if (!$this->contains($vector)) {
             throw new DomainException(

--- a/src/Eris/Quantifier/Evaluation.php
+++ b/src/Eris/Quantifier/Evaluation.php
@@ -1,6 +1,8 @@
 <?php
 namespace Eris\Quantifier;
 
+use Eris\Generator\GeneratedValue;
+
 /**
  * TODO: change namespace. To what?
  */
@@ -22,7 +24,7 @@ final class Evaluation
         $this->onSuccess = function() {};
     }
 
-    public function with($values)
+    public function with(GeneratedValue $values)
     {
         $this->values = $values;
         return $this;
@@ -43,11 +45,14 @@ final class Evaluation
     public function execute()
     {
         try {
-            call_user_func_array($this->assertion, $this->values);
+            call_user_func_array(
+                $this->assertion,
+                $this->values->unbox()
+            );
         } catch (\PHPUnit_Framework_AssertionFailedError $e) {
             call_user_func($this->onFailure, $this->values, $e);
             return;
         }
-        call_user_func_array($this->onSuccess, $this->values);
+        call_user_func($this->onSuccess, $this->values);
     }
 }

--- a/src/Eris/Quantifier/ForAll.php
+++ b/src/Eris/Quantifier/ForAll.php
@@ -78,6 +78,9 @@ class ForAll
                 foreach ($this->generators as $name => $generator) {
                     $currentSizeIndex = $iteration % count($sizes);
                     $value = $generator($sizes[$currentSizeIndex]);
+                    if (!($value instanceof GeneratedValue)) {
+                        throw new RuntimeException("The value returned by a generator should be an instance of GeneratedValue, but it is " . var_export($value, true));
+                    }
                     $generatedValues[] = $value;
                     $values[] = $value->unbox();
                 }

--- a/src/Eris/Quantifier/ForAll.php
+++ b/src/Eris/Quantifier/ForAll.php
@@ -3,6 +3,7 @@ namespace Eris\Quantifier;
 
 use Eris\Antecedent;
 use Eris\Generator;
+use Eris\Generator\GeneratedValue;
 use Eris\Shrinker;
 use BadMethodCallException;
 use PHPUnit_Framework_Constraint;
@@ -76,6 +77,9 @@ class ForAll
                 foreach ($this->generators as $name => $generator) {
                     $currentSizeIndex = $iteration % count($sizes);
                     $value = $generator($sizes[$currentSizeIndex]);
+                    if ($value instanceof GeneratedValue) {
+                        $value = $value->unbox();
+                    }
                     $values[] = $value;
                 }
                 if (!$this->antecedentsAreSatisfied($values)) {

--- a/src/Eris/Sample.php
+++ b/src/Eris/Sample.php
@@ -21,7 +21,7 @@ class Sample
     public function repeat($times)
     {
         for ($i = 0; $i < $times; $i++) {
-            $this->collected[] = $this->generator->__invoke(self::DEFAULT_SIZE);
+            $this->collected[] = $this->generator->__invoke(self::DEFAULT_SIZE)->unbox();
         }
         return $this;
     }
@@ -31,12 +31,12 @@ class Sample
         if ($nextValue === null) {
             $nextValue = $this->generator->__invoke(self::DEFAULT_SIZE);
         }
-        $this->collected[] = $nextValue;
+        $this->collected[] = $nextValue->unbox();
         while ($value = $this->generator->shrink($nextValue)) {
-            if ($value === $nextValue) {
+            if ($value->unbox() === $nextValue->unbox()) {
                 break;
             }
-            $this->collected[] = $value;
+            $this->collected[] = $value->unbox();
             $nextValue = $value;
         }
         return $this;

--- a/src/Eris/Shrinker/Random.php
+++ b/src/Eris/Shrinker/Random.php
@@ -1,6 +1,7 @@
 <?php
 namespace Eris\Shrinker;
 
+use Eris\Generator\GeneratedValue;
 use Eris\Generator\TupleGenerator;
 use Eris\Quantifier\Evaluation;
 use PHPUnit_Framework_AssertionFailedError as AssertionFailed;
@@ -33,7 +34,7 @@ class Random // implements Shrinker
     /**
      * Precondition: $values should fail $this->assertion
      */
-    public function from(array $elements, AssertionFailed $exception)
+    public function from(GeneratedValue $elements, AssertionFailed $exception)
     {
         $onBadShrink = function() use (&$exception) {
             $this->attempts->increase();
@@ -50,7 +51,7 @@ class Random // implements Shrinker
         while (!$this->timeLimit->hasBeenReached()) {
             $elementsAfterShrink = $this->generator->shrink($elements);
 
-            if ($elementsAfterShrink === $elements) {
+            if ($elementsAfterShrink == $elements) {
                 $onBadShrink();
                 continue;
             }
@@ -75,7 +76,7 @@ class Random // implements Shrinker
         );
     }
 
-    private function checkGoodShrinkConditions(array $values)
+    private function checkGoodShrinkConditions(GeneratedValue $values)
     {
         foreach ($this->goodShrinkConditions as $condition) {
             if (!$condition($values)) {

--- a/test/Eris/ExampleEnd2EndTest.php
+++ b/test/Eris/ExampleEnd2EndTest.php
@@ -150,6 +150,20 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testMapTest()
+    {
+        $this->runExample('MapTest.php');
+        $this->assertTestsAreFailing(2);
+        $this->assertRegexp(
+            "/number is not less than 100/",
+            (string) $this->theTest('testShrinkingJustMappedValues')->failure
+        );
+        $this->assertRegexp(
+            "/triple sum array/",
+            (string) $this->theTest('testShrinkingMappedValuesInsideOtherGenerators')->failure
+        );
+    }
+
     private function setEnvironmentVariable($name, $value)
     {
         $this->environment[$name] = $value;

--- a/test/Eris/Generator/BooleanGeneratorTest.php
+++ b/test/Eris/Generator/BooleanGeneratorTest.php
@@ -27,6 +27,6 @@ class BooleanGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testShrinkOnlyAcceptsElementsOfTheDomainAsParameters()
     {
         $generator = new BooleanGenerator();
-        $generator->shrink(10);
+        $generator->shrink(GeneratedValue::fromJustValue(10));
     }
 }

--- a/test/Eris/Generator/CharacterGeneratorTest.php
+++ b/test/Eris/Generator/CharacterGeneratorTest.php
@@ -12,7 +12,7 @@ class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = CharacterGenerator::ascii();
         for ($i = 0; $i < 100; $i++) {
-            $value = $generator($this->size);
+            $value = $generator($this->size)->unbox();
             $this->assertEquals(1, strlen($value));
             $this->assertGreaterThanOrEqual(0, ord($value));
             $this->assertLessThanOrEqual(127, ord($value));
@@ -24,7 +24,7 @@ class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = CharacterGenerator::printableAscii();
         for ($i = 0; $i < 100; $i++) {
-            $value = $generator($this->size);
+            $value = $generator($this->size)->unbox();
             $this->assertEquals(1, strlen($value));
             $this->assertGreaterThanOrEqual(32, ord($value));
             $this->assertLessThanOrEqual(127, ord($value));
@@ -35,13 +35,14 @@ class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testCharacterGeneratorsShrinkByConventionToTheLowestCodePoint()
     {
         $generator = CharacterGenerator::ascii();
-        $this->assertEquals('@', $generator->shrink('A'));
+        $this->assertEquals('@', $generator->shrink(GeneratedValue::fromJustValue('A', 'character'))->unbox());
     }
 
     public function testTheLowestCodePointCannotBeShrunk()
     {
         $generator = new CharacterGenerator(65, 90);
-        $this->assertEquals('A', $generator->shrink('A'));
+        $lowest = GeneratedValue::fromJustValue('A', 'character');
+        $this->assertEquals($lowest, $generator->shrink($lowest));
     }
 
     public function testContainsOnlyTheSpecifiedRange()

--- a/test/Eris/Generator/CharacterGeneratorTest.php
+++ b/test/Eris/Generator/CharacterGeneratorTest.php
@@ -12,11 +12,12 @@ class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = CharacterGenerator::ascii();
         for ($i = 0; $i < 100; $i++) {
-            $value = $generator($this->size)->unbox();
+            $generatedValue = $generator($this->size);
+            $value = $generatedValue->unbox();
             $this->assertEquals(1, strlen($value));
             $this->assertGreaterThanOrEqual(0, ord($value));
             $this->assertLessThanOrEqual(127, ord($value));
-            $this->assertTrue($generator->contains($value));
+            $this->assertTrue($generator->contains($generatedValue));
         }
     }
 
@@ -24,11 +25,12 @@ class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = CharacterGenerator::printableAscii();
         for ($i = 0; $i < 100; $i++) {
-            $value = $generator($this->size)->unbox();
+            $generatedValue = $generator($this->size);
+            $value = $generatedValue->unbox();
             $this->assertEquals(1, strlen($value));
             $this->assertGreaterThanOrEqual(32, ord($value));
             $this->assertLessThanOrEqual(127, ord($value));
-            $this->assertTrue($generator->contains($value));
+            $this->assertTrue($generator->contains($generatedValue));
         }
     }
 
@@ -48,9 +50,9 @@ class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testContainsOnlyTheSpecifiedRange()
     {
         $generator = CharacterGenerator::ascii();
-        $this->assertTrue($generator->contains("\0"));
-        $this->assertTrue($generator->contains("A"));
-        $this->assertTrue($generator->contains("b"));
-        $this->assertFalse($generator->contains("é"));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue("\0")));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue("A")));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue("b")));
+        $this->assertFalse($generator->contains(GeneratedValue::fromJustValue("é")));
     }
 }

--- a/test/Eris/Generator/ChooseGeneratorTest.php
+++ b/test/Eris/Generator/ChooseGeneratorTest.php
@@ -28,10 +28,10 @@ class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new ChooseGenerator(-10, 200);
         $value = $generator($this->size);
         $target = 10;
-        $distance = abs($target - $value);
+        $distance = abs($target - $value->unbox());
         for ($i = 0; $i < 190; $i++) {
             $newValue = $generator->shrink($value);
-            $newDistance = abs($target - $newValue);
+            $newDistance = abs($target - $newValue->unbox());
             $this->assertTrue(
                 $newDistance <= $distance,
                 "Failed asserting that {$newDistance} is less than or equal to {$distance}"
@@ -39,7 +39,7 @@ class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
             $value = $newValue;
             $distance = $newDistance;
         }
-        $this->assertSame($target, $value);
+        $this->assertSame($target, $value->unbox());
     }
 
     public function testUniformity()
@@ -51,16 +51,16 @@ class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertGreaterThan(
             40,
-            count(array_filter($values, function($n) { return $n > 0; })),
+            count(array_filter($values, function($n) { return $n->unbox() > 0; })),
             "The positive numbers should be a vast majority given the interval [-10, 10000]"
         );
     }
 
-    public function testCannotShrinkStopsToZero()
+    public function testShrinkingStopsToZero()
     {
         $generator = new ChooseGenerator($lowerLimit = 0, $upperLimit = 0);
         $lastValue = $generator($this->size);
-        $this->assertSame(0, $generator->shrink($lastValue));
+        $this->assertSame(0, $generator->shrink($lastValue)->unbox());
     }
 
     /**
@@ -74,8 +74,8 @@ class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testCanGenerateSingleInteger()
     {
         $generator = new ChooseGenerator(42, 42);
-        $this->assertSame(42, $generator($this->size));
-        $this->assertSame(42, $generator->shrink($generator($this->size)));
+        $this->assertSame(42, $generator($this->size)->unbox());
+        $this->assertSame(42, $generator->shrink($generator($this->size))->unbox());
     }
 
     /**
@@ -84,7 +84,7 @@ class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
     {
         $generator = new ChooseGenerator(100, 200);
-        $generator->shrink(300);
+        $generator->shrink(GeneratedValue::fromJustValue(300));
     }
 
     public function testTheOrderOfBoundariesDoesNotMatter()

--- a/test/Eris/Generator/ConstantGeneratorTest.php
+++ b/test/Eris/Generator/ConstantGeneratorTest.php
@@ -12,7 +12,7 @@ class ConstantGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new ConstantGenerator(true);
         for ($i = 0; $i < 50; $i++) {
-            $this->assertTrue($generator($this->size));
+            $this->assertTrue($generator($this->size)->unbox());
         }
     }
 
@@ -21,15 +21,15 @@ class ConstantGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new ConstantGenerator(true);
         $element = $generator($this->size);
         for ($i = 0; $i < 50; $i++) {
-            $this->assertTrue($generator->shrink($element));
+            $this->assertTrue($generator->shrink($element)->unbox());
         }
     }
 
     public function testContainsOnlyTheValue()
     {
         $generator = new ConstantGenerator(true);
-        $this->assertTrue($generator->contains(true));
-        $this->assertFalse($generator->contains(42));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue(true)));
+        $this->assertFalse($generator->contains(GeneratedValue::fromJustValue(42)));
     }
 
     /**
@@ -38,6 +38,6 @@ class ConstantGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testShrinkOnlyAcceptsElementsOfTheDomainAsParameters()
     {
         $generator = new ConstantGenerator(5);
-        $generator->shrink(10);
+        $generator->shrink(GeneratedValue::fromJustValue(10));
     }
 }

--- a/test/Eris/Generator/DateGeneratorTest.php
+++ b/test/Eris/Generator/DateGeneratorTest.php
@@ -29,7 +29,7 @@ class DateGeneratorTest extends \PHPUnit_Framework_TestCase
             new DateTime("2014-01-02T23:59:59")
         );
         $value = $generator($this->size);
-        $generator->shrink(new DateTime("2014-01-10T00:00:00"));
+        $generator->shrink(GeneratedValue::fromJustValue(new DateTime("2014-01-10T00:00:00"), 'date'));
     }
 
     public function testDateTimeShrinkGeometrically()
@@ -40,7 +40,10 @@ class DateGeneratorTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals(
             new DateTime("2014-01-01T16:00:00"),
-            $generator->shrink(new DateTime("2014-01-02T08:00:00"))
+            $generator->shrink(GeneratedValue::fromJustValue(
+                new DateTime("2014-01-02T08:00:00"),
+                'date'
+            ))->unbox()
         );
     }
 
@@ -50,13 +53,16 @@ class DateGeneratorTest extends \PHPUnit_Framework_TestCase
             $lowerLimit = new DateTime("2014-01-01T00:00:00"),
             new DateTime("2014-01-02T23:59:59")
         );
-        $value = new DateTime("2014-01-01T00:01:00");
+        $value = GeneratedValue::fromJustValue(
+            new DateTime("2014-01-01T00:01:00"),
+            'date'
+        );
         for ($i = 0; $i < 10; $i++) {
             $value = $generator->shrink($value);
         }
         $this->assertEquals(
             $lowerLimit,
-            $value
+            $value->unbox()
         );
     }
 }

--- a/test/Eris/Generator/ElementsGeneratorTest.php
+++ b/test/Eris/Generator/ElementsGeneratorTest.php
@@ -24,17 +24,18 @@ class ElementsGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testASingleValueCannotShrinkGivenThereIsNoExplicitRelationshipBetweenTheValuesInTheDomain()
     {
         $generator = ElementsGenerator::fromArray(['A', 2, false]);
-        $this->assertSame(2, $generator->shrink(2));
+        $singleValue = GeneratedValue::fromJustValue(2, 'elements');
+        $this->assertEquals($singleValue, $generator->shrink($singleValue));
     }
 
     public function testOnlyContainsTheElementsGeneratorOfTheGivenDomain()
     {
         $generator = ElementsGenerator::fromArray(['A', 2]);
-        $this->assertFalse($generator->contains(1));
-        $this->assertTrue($generator->contains('A'));
-        $this->assertTrue($generator->contains(2));
+        $this->assertFalse($generator->contains(GeneratedValue::fromJustValue(1)));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue('A')));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue(2)));
         // disregarding types
-        $this->assertTrue($generator->contains('2'));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue('2')));
     }
 
     /**
@@ -43,6 +44,6 @@ class ElementsGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
     {
         $generator = ElementsGenerator::fromArray(['A', 1]);
-        $generator->shrink(2);
+        $generator->shrink(GeneratedValue::fromJustValue(2));
     }
 }

--- a/test/Eris/Generator/ElementsGeneratorTest.php
+++ b/test/Eris/Generator/ElementsGeneratorTest.php
@@ -15,7 +15,7 @@ class ElementsGeneratorTest extends \PHPUnit_Framework_TestCase
         $generated = $generator($this->size);
         for ($i = 0; $i < 1000; $i++) {
             $this->assertContains(
-                $generated,
+                $generated->unbox(),
                 $array
             );
         }

--- a/test/Eris/Generator/FloatGeneratorTest.php
+++ b/test/Eris/Generator/FloatGeneratorTest.php
@@ -15,8 +15,8 @@ class FloatGeneratorTest extends \PHPUnit_Framework_TestCase
         $trials = 500;
         for ($i = 0; $i < $trials; $i++) {
             $value = $generator($this->size);
-            $this->assertInternalType('float', $value);
-            $sum += $value;
+            $this->assertInternalType('float', $value->unbox());
+            $sum += $value->unbox();
         }
         $mean = $sum / $trials;
         // over a 300 size
@@ -26,16 +26,16 @@ class FloatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testShrinksLinearly()
     {
         $generator = new FloatGenerator();
-        $this->assertSame(3.5, $generator->shrink(4.5));
-        $this->assertSame(-2.5, $generator->shrink(-3.5));
+        $this->assertSame(3.5, $generator->shrink(GeneratedValue::fromJustValue(4.5))->unbox());
+        $this->assertSame(-2.5, $generator->shrink(GeneratedValue::fromJustValue(-3.5))->unbox());
     }
 
     public function testWhenBothSignsArePossibleCannotShrinkBelowZero()
     {
         $generator = new FloatGenerator();
-        $this->assertSame(0.0, $generator->shrink(0.0));
-        $this->assertSame(0.0, $generator->shrink(0.5));
-        $this->assertSame(0.0, $generator->shrink(-0.5));
+        $this->assertSame(0.0, $generator->shrink(GeneratedValue::fromJustValue(0.0))->unbox());
+        $this->assertSame(0.0, $generator->shrink(GeneratedValue::fromJustValue(0.5))->unbox());
+        $this->assertSame(0.0, $generator->shrink(GeneratedValue::fromJustValue(-0.5))->unbox());
     }
 
     /**
@@ -44,6 +44,6 @@ class FloatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
     {
         $generator = new FloatGenerator(100.12, 200.12);
-        $generator->shrink(300);
+        $generator->shrink(GeneratedValue::fromJustValue(300));
     }
 }

--- a/test/Eris/Generator/GeneratedValueTest.php
+++ b/test/Eris/Generator/GeneratedValueTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class GeneratedValueTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCanBeMappedOver()
+    public function testCanBeMappedToDeriveValues()
     {
         $initialValue = GeneratedValue::fromJustValue(
             3,
@@ -21,6 +21,22 @@ class GeneratedValueTest extends \PHPUnit_Framework_TestCase
                 },
                 'derived-generator'
             )
+        );
+    }
+
+    public function testDerivedValueCanBeAnnotatedWithNewGeneratorNameWithoutBeingChanged()
+    {
+        $initialValue = GeneratedValue::fromJustValue(
+            3,
+            'my-generator'
+        );
+        $this->assertEquals(
+            GeneratedValue::fromValueAndInput(
+                3,
+                $initialValue,
+                'derived-generator'
+            ),
+            $initialValue->derivedIn('derived-generator')
         );
     }
 

--- a/test/Eris/Generator/GeneratedValueTest.php
+++ b/test/Eris/Generator/GeneratedValueTest.php
@@ -3,6 +3,27 @@ namespace Eris\Generator;
 
 class GeneratedValueTest extends \PHPUnit_Framework_TestCase
 {
+    public function testCanBeMappedOver()
+    {
+        $initialValue = GeneratedValue::fromJustValue(
+            3,
+            'my-generator'
+        );
+        $this->assertEquals(
+            GeneratedValue::fromValueAndInput(
+                6,
+                $initialValue,
+                'derived-generator'
+            ),
+            $initialValue->map(
+                function($value) {
+                    return $value * 2;
+                },
+                'derived-generator'
+            )
+        );
+    }
+
     public function testCanBeRepresentedOnOutput()
     {
         $generatedValue = GeneratedValue::fromValueAndInput(

--- a/test/Eris/Generator/GeneratedValueTest.php
+++ b/test/Eris/Generator/GeneratedValueTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace Eris\Generator;
+
+class GeneratedValueTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanBeRepresentedOnOutput()
+    {
+        $generatedValue = GeneratedValue::fromValueAndInput(
+            422,
+            GeneratedValue::fromJustValue(211),
+            'map'
+        );
+        $this->assertInternalType('string', $generatedValue->__toString());
+        $this->assertRegexp('/value.*422/', $generatedValue->__toString());
+        $this->assertRegexp('/211/', $generatedValue->__toString());
+        $this->assertRegexp('/generator.*map/', $generatedValue->__toString());
+    }
+}

--- a/test/Eris/Generator/IntegerGeneratorTest.php
+++ b/test/Eris/Generator/IntegerGeneratorTest.php
@@ -26,10 +26,10 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
         $value = $generator($this->size);
         for ($i = 0; $i < 20; $i++) {
             $newValue = $generator->shrink($value);
-            $this->assertTrue(in_array(abs($value - $newValue), [0, 1]));
+            $this->assertTrue(in_array(abs($value->unbox() - $newValue->unbox()), [0, 1]));
             $value = $newValue;
         }
-        $this->assertSame(0, $value);
+        $this->assertSame(0, $value->unbox());
     }
 
     public function testUniformity()
@@ -41,7 +41,7 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertGreaterThan(
             400,
-            count(array_filter($values, function($n) { return $n > 0; })),
+            count(array_filter($values, function($n) { return $n->unbox() > 0; })),
             "The positive numbers should be a vast majority given the interval [-10, 10000]"
         );
     }
@@ -50,24 +50,24 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new IntegerGenerator();
         $lastValue = $generator($size = 0);
-        $this->assertSame(0, $generator->shrink($lastValue));
+        $this->assertSame(0, $generator->shrink($lastValue)->unbox());
     }
 
     public function testPosAlreadyStartsFromStrictlyPositiveValues()
     {
         $generator = pos();
-        $this->assertGreaterThan(0, $generator->__invoke(0));
+        $this->assertGreaterThan(0, $generator->__invoke(0)->unbox());
     }
 
     public function testNegAlreadyStartsFromStrictlyNegativeValues()
     {
         $generator = neg();
-        $this->assertLessThan(0, $generator->__invoke(0));
+        $this->assertLessThan(0, $generator->__invoke(0)->unbox());
     }
 
     public function testNatStartsFromZero()
     {
         $generator = nat();
-        $this->assertEquals(0, $generator->__invoke(0));
+        $this->assertEquals(0, $generator->__invoke(0)->unbox());
     }
 }

--- a/test/Eris/Generator/MapGeneratorTest.php
+++ b/test/Eris/Generator/MapGeneratorTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Eris\Generator;
+
+class MapGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->size = 10;
+    }
+    
+    public function testGeneratesAGeneratedValueObjectKeepingTrackOfTheInputUsed()
+    {
+        $generator = new MapGenerator(
+            function($n) { return $n * 2; },
+            ConstantGenerator::box(1)
+        );
+        $this->assertEquals(
+            GeneratedValue::fromValueAndInput(
+                2,
+                1
+            ),
+            $generator->__invoke($this->size)
+        );
+        
+    }
+}

--- a/test/Eris/Generator/MapGeneratorTest.php
+++ b/test/Eris/Generator/MapGeneratorTest.php
@@ -8,19 +8,42 @@ class MapGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->size = 10;
     }
     
-    public function testGeneratesAGeneratedValueObjectKeepingTrackOfTheInputUsed()
+    public function testGeneratesAGeneratedValueObject()
     {
         $generator = new MapGenerator(
             function($n) { return $n * 2; },
             ConstantGenerator::box(1)
         );
         $this->assertEquals(
-            GeneratedValue::fromValueAndInput(
-                2,
-                1
-            ),
-            $generator->__invoke($this->size)
+            2,
+            $generator->__invoke($this->size)->unbox()
         );
-        
+    }
+
+    public function testShrinksTheOriginalInput()
+    {
+        $generator = new MapGenerator(
+            function($n) { return $n * 2; },
+            new ChooseGenerator(1, 100)
+        );
+        $element = $generator->__invoke($this->size);
+        $elementAfterShrink = $generator->shrink($element);
+        $this->assertTrue(
+            $elementAfterShrink->unbox() <= $element->unbox(),
+            "Element should have diminished in size"
+        );
+    }
+
+    public function testChecksTheContainmentOfTheOriginalInput()
+    {
+        $generator = new MapGenerator(
+            function($n) { return $n * 2; },
+            new ChooseGenerator(1, 100)
+        );
+        $element = $generator->__invoke($this->size);
+        $this->assertTrue(
+            $generator->contains($element),
+            "Generator does not contain the element $element, which has previously generated"
+        );
     }
 }

--- a/test/Eris/Generator/NamesGeneratorTest.php
+++ b/test/Eris/Generator/NamesGeneratorTest.php
@@ -7,7 +7,7 @@ class NamesGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = NamesGenerator::defaultDataSet();
         for ($i = 5; $i < 50; $i++) {
-            $value = $generator($maxLength = $i);
+            $value = $generator($maxLength = $i)->unbox();
             $this->assertTrue(
                 $maxLength >= strlen($value),
                 "Names generator is not respecting the generation size. Asked a name with max size {$maxLength} and returned {$value}"
@@ -24,26 +24,40 @@ class NamesGeneratorTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testShrinksToTheNameWithTheImmediatelyLowerLengthWhichHasTheMinimumDistance()
+    public static function namesToShrink()
+    {
+        return [
+            ["Malene", "Maxence"],
+            ["Columban", "Columbano"],
+            ["Carol-Anne", "Carole-Anne"],
+            ["Annie", "Zinnia"],
+            ["Aletta", "Lucetta"],
+            ["Tekla", "Thekla"],
+            ["Ursin", "Ursine"],
+            ["Gwennan", "Gwenegan"],
+            ["Eliane", "Eliabel"],
+            ["Ed", "Ed"],
+            ["Di", "Di"],
+        ];
+    }
+
+    /**
+     * @dataProvider namesToShrink
+     */
+    public function testShrinksToTheNameWithTheImmediatelyLowerLengthWhichHasTheMinimumDistance($shrunk, $original)
     {
         $generator = NamesGenerator::defaultDataSet();
-        $this->assertEquals("Malene", $generator->shrink("Maxence"));
-        $this->assertEquals("Columban", $generator->shrink("Columbano"));
-        $this->assertEquals("Carol-Anne", $generator->shrink("Carole-Anne"));
-        $this->assertEquals("Annie", $generator->shrink("Zinnia"));
-        $this->assertEquals("Aletta", $generator->shrink("Lucetta"));
-        $this->assertEquals("Tekla", $generator->shrink("Thekla"));
-        $this->assertEquals("Ursin", $generator->shrink("Ursine"));
-        $this->assertEquals("Gwennan", $generator->shrink("Gwenegan"));
-        $this->assertEquals("Eliane", $generator->shrink("Eliabel"));
-        $this->assertEquals("Ed", $generator->shrink("Ed"));
-        $this->assertEquals("Di", $generator->shrink("Di"));
+        $this->assertEquals(
+            $shrunk,
+            $generator->shrink(GeneratedValue::fromJustValue($original))
+                ->unbox()
+        );
     }
 
     public function testContainsAllTheNamesInTheSpecifiedDataSet()
     {
         $generator = NamesGenerator::defaultDataSet();
-        $this->assertTrue($generator->contains("Bob"));
-        $this->assertFalse($generator->contains("Daitarn"));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue("Bob")));
+        $this->assertFalse($generator->contains(GeneratedValue::fromJustValue("Daitarn")));
     }
 }

--- a/test/Eris/Generator/OneOfGeneratorTest.php
+++ b/test/Eris/Generator/OneOfGeneratorTest.php
@@ -36,13 +36,4 @@ class OneOfGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new OneOfGenerator([]);
         $element = $generator($this->size);
     }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testShrinkSomethingThatIsNotInDomain()
-    {
-        $generator = new OneOfGenerator([42, 21]);
-        $generator->shrink(GeneratedValue::fromJustValue('something'));
-    }
 }

--- a/test/Eris/Generator/OneOfGeneratorTest.php
+++ b/test/Eris/Generator/OneOfGeneratorTest.php
@@ -18,13 +18,13 @@ class OneOfGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $element = $generator($this->size);
 
-        $this->assertTrue($this->singleElementGenerator->contains($element));
+        $this->assertTrue($generator->contains($element));
     }
 
     public function testConstructWithNonGenerators()
     {
         $generator = new OneOfGenerator([42, 42]);
-        $element = $generator($this->size);
+        $element = $generator($this->size)->unbox();
         $this->assertEquals(42, $element);
     }
 
@@ -37,34 +37,12 @@ class OneOfGeneratorTest extends \PHPUnit_Framework_TestCase
         $element = $generator($this->size);
     }
 
-    public function testShrinkDisjointDomains()
-    {
-        $generator = new OneOfGenerator([42, 21]);
-        $this->assertEquals(42, $generator->shrink(42));
-        $this->assertEquals(21, $generator->shrink(21));
-    }
-
-    public function testShrinkIntersectingDomains()
-    {
-        $generator = new OneOfGenerator([
-            new ChooseGenerator(1, 100),
-            new ChooseGenerator(10, 100),
-        ]);
-
-        $element = 42;
-        for ($i=0; $i<100; $i++) {
-            $element = $generator->shrink($element);
-        }
-
-        $this->assertEquals(1, $element);
-    }
-
     /**
-     * @expectedException DomainException
+     * @expectedException InvalidArgumentException
      */
     public function testShrinkSomethingThatIsNotInDomain()
     {
         $generator = new OneOfGenerator([42, 21]);
-        $generator->shrink('something');
+        $generator->shrink(GeneratedValue::fromJustValue('something'));
     }
 }

--- a/test/Eris/Generator/RegexGeneratorTest.php
+++ b/test/Eris/Generator/RegexGeneratorTest.php
@@ -35,6 +35,7 @@ class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingIsNotImplementedYet()
     {
         $generator = new RegexGenerator(".*");
-        $this->assertEquals("something", $generator->shrink("something"));
+        $word = GeneratedValue::fromJustValue("something");
+        $this->assertEquals($word, $generator->shrink($word));
     }
 }

--- a/test/Eris/Generator/RegexGeneratorTest.php
+++ b/test/Eris/Generator/RegexGeneratorTest.php
@@ -27,8 +27,11 @@ class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new RegexGenerator($expression);
         for ($i = 0; $i < 100; $i++) {
-            $value = $generator($this->size);
-            $this->assertTrue($generator->contains($value), "Failed asserting that " . var_export($value, true) . " matches the regexp $expression");
+            $value = $generator($this->size)->unbox();
+            $this->assertTrue(
+                $generator->contains($value), 
+                "Failed asserting that " . var_export($value, true) . " matches the regexp $expression"
+            );
         }
     }
 

--- a/test/Eris/Generator/RegexGeneratorTest.php
+++ b/test/Eris/Generator/RegexGeneratorTest.php
@@ -29,7 +29,7 @@ class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
         for ($i = 0; $i < 100; $i++) {
             $value = $generator($this->size)->unbox();
             $this->assertTrue(
-                $generator->contains($value), 
+                $generator->contains(GeneratedValue::fromJustValue($value)), 
                 "Failed asserting that " . var_export($value, true) . " matches the regexp $expression"
             );
         }

--- a/test/Eris/Generator/SequenceGeneratorTest.php
+++ b/test/Eris/Generator/SequenceGeneratorTest.php
@@ -15,7 +15,7 @@ class SequenceGeneratorTest extends \PHPUnit_Framework_TestCase
         $countLessThanSize = 0;
         $countEqualToSize = 0;
         for ($size = 0; $size < 400; $size++) {
-            $sequenceSize = count($generator($size));
+            $sequenceSize = count($generator($size)->unbox());
 
             if ($sequenceSize < $size) {
                 $countLessThanSize++;
@@ -41,16 +41,16 @@ class SequenceGeneratorTest extends \PHPUnit_Framework_TestCase
         $elements = $generator($this->size);
         $elementsAfterShrink = $generator->shrink($elements);
 
-        $this->assertLessThanOrEqual(count($elements), count($elementsAfterShrink));
-        $this->assertLessThanOrEqual(array_sum($elements), array_sum($elementsAfterShrink));
+        $this->assertLessThanOrEqual(count($elements->unbox()), count($elementsAfterShrink->unbox()));
+        $this->assertLessThanOrEqual(array_sum($elements->unbox()), array_sum($elementsAfterShrink->unbox()));
     }
 
     public function testShrinkEmptySequence()
     {
         $generator = new SequenceGenerator($this->singleElementGenerator);
         $elements = $generator($size = 0);
-        $this->assertEquals(0, count($elements));
-        $this->assertEquals(0, count($generator->shrink($elements)));
+        $this->assertEquals(0, count($elements->unbox()));
+        $this->assertEquals(0, count($generator->shrink($elements)->unbox()));
     }
 
     public function testShrinkEventuallyEndsUpWithAnEmptySequence()
@@ -58,7 +58,7 @@ class SequenceGeneratorTest extends \PHPUnit_Framework_TestCase
         $numberOfShrinks = 0;
         $generator = new SequenceGenerator($this->singleElementGenerator);
         $elements = $generator($this->size);
-        while (count($elements) > 0) {
+        while (count($elements->unbox()) > 0) {
             if ($numberOfShrinks++ > 10000) {
                 $this->fail('Too many shrinks');
             }
@@ -66,39 +66,9 @@ class SequenceGeneratorTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testContainsElementsWhenElementsAreContainedInGivenGenerator()
-    {
-        $generator = new SequenceGenerator($this->singleElementGenerator);
-        $elements = [
-            $this->singleElementGenerator->__invoke($this->size),
-            $this->singleElementGenerator->__invoke($this->size),
-        ];
-        $this->assertTrue($generator->contains($elements));
-    }
-
-    public function testDoNotContainsElementsWhenElementAreNotContainedInGivenGenerator()
-    {
-        $aString = 'a string';
-        $this->assertFalse($this->singleElementGenerator->contains($aString));
-        $generator = new SequenceGenerator($this->singleElementGenerator);
-        $elements = [$aString, $aString];
-        $this->assertFalse($generator->contains($elements));
-    }
-
     public function testContainsAnEmptySequence()
     {
         $generator = new SequenceGenerator($this->singleElementGenerator);
-        $this->assertTrue($generator->contains([]));
-    }
-
-    /**
-     * @expectedException DomainException
-     */
-    public function testCannotShrinkSomethingThatIsNotContainedInDomain()
-    {
-        $aString = 'a string';
-        $this->assertFalse($this->singleElementGenerator->contains($aString));
-        $generator = new SequenceGenerator($this->singleElementGenerator);
-        $generator->shrink([$aString]);
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue([])));
     }
 }

--- a/test/Eris/Generator/SetGeneratorTest.php
+++ b/test/Eris/Generator/SetGeneratorTest.php
@@ -15,7 +15,7 @@ class SetGeneratorTest extends \PHPUnit_Framework_TestCase
         $countLessThanSize = 0;
         $countEqualToSize = 0;
         for ($size = 0; $size < 400; $size++) {
-            $subsetSize = count($generator($size));
+            $subsetSize = count($generator($size)->unbox());
 
             if ($subsetSize < $size) {
                 $countLessThanSize++;
@@ -39,7 +39,7 @@ class SetGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new SetGenerator($this->singleElementGenerator);
         for ($size = 0; $size < 10; $size++) {
-            $generated = $generator($size);
+            $generated = $generator($size)->unbox();
             $this->assertNoRepeatedElements($generated);
         }
     }
@@ -49,7 +49,7 @@ class SetGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new SetGenerator(new ConstantGenerator(42));
         for ($size = 0; $size < 5; $size++) {
             $generated = $generator($size);
-            $this->assertLessThanOrEqual(1, count($generated));
+            $this->assertLessThanOrEqual(1, count($generated->unbox()));
         }
     }
 
@@ -59,44 +59,25 @@ class SetGeneratorTest extends \PHPUnit_Framework_TestCase
         $elements = $generator($this->size);
         $elementsAfterShrink = $generator->shrink($elements);
 
-        $this->assertLessThanOrEqual(count($elements), count($elementsAfterShrink));
-        $this->assertNoRepeatedElements($elementsAfterShrink);
+        $this->assertLessThanOrEqual(count($elements->unbox()), count($elementsAfterShrink->unbox()));
+        $this->assertNoRepeatedElements($elementsAfterShrink->unbox());
     }
 
     public function testShrinkEmptySet()
     {
         $generator = new SetGenerator($this->singleElementGenerator);
         $elements = $generator($size = 0);
-        $this->assertEquals(0, count($elements));
-        $this->assertEquals(0, count($generator->shrink($elements)));
-    }
-
-    public function testContainsElementsWhenElementsAreContainedInGivenGenerator()
-    {
-        $generator = new SetGenerator($this->singleElementGenerator);
-        $elements = [
-            $this->singleElementGenerator->__invoke($this->size),
-            $this->singleElementGenerator->__invoke($this->size),
-        ];
-        $this->assertTrue($generator->contains($elements));
-    }
-
-    public function testDoesNotContainElementsWhenElementsAreNotContainedInGivenGenerator()
-    {
-        $aString = 'a string';
-        $this->assertFalse($this->singleElementGenerator->contains($aString));
-        $generator = new SetGenerator($this->singleElementGenerator);
-        $elements = [$aString, $aString];
-        $this->assertFalse($generator->contains($elements));
+        $this->assertEquals(0, count($elements->unbox()));
+        $this->assertEquals(0, count($generator->shrink($elements)->unbox()));
     }
 
     public function testContainsAnEmptySet()
     {
         $generator = new SetGenerator($this->singleElementGenerator);
-        $this->assertTrue($generator->contains([]));
+        $this->assertTrue($generator->contains(GeneratedValue::fromJustValue([])));
     }
 
-    private function assertNoRepeatedElements($generated)
+    private function assertNoRepeatedElements(array $generated)
     {
         sort($generated);
         $this->assertTrue(

--- a/test/Eris/Generator/StringGeneratorTest.php
+++ b/test/Eris/Generator/StringGeneratorTest.php
@@ -10,7 +10,7 @@ class StringGeneratorTest extends \PHPUnit_Framework_TestCase
         $lengths = [];
         $usedChars = [];
         for ($i = 0; $i < 1000; $i++) {
-            $value = $generator($size);
+            $value = $generator($size)->unbox();
             $length = strlen($value);
             $this->assertLessThanOrEqual(10, $length);
             $lengths = $this->accumulateLengths($lengths, $length);
@@ -25,7 +25,7 @@ class StringGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generationSize = 100;
         $generator = new StringGenerator();
-        $value = $generator($generationSize);
+        $value = $generator($generationSize)->unbox();
 
         $this->assertLessThanOrEqual($generationSize, strlen($value));
     }
@@ -34,14 +34,14 @@ class StringGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new StringGenerator();
         $lastValue = $generator($size = 10);
-        $this->assertSame('abcde', $generator->shrink('abcdef'));
+        $this->assertSame('abcde', $generator->shrink(GeneratedValue::fromJustValue('abcdef'))->unbox());
     }
 
     public function testCannotShrinkTheEmptyString()
     {
         $generator = new StringGenerator();
-        $lastValue = $generator($size = 10);
-        $this->assertSame('', $generator->shrink(''));
+        $minimumValue = GeneratedValue::fromJustValue('');
+        $this->assertEquals($minimumValue, $generator->shrink($minimumValue));
     }
 
     private function accumulateLengths(array $lengths, $length)
@@ -63,14 +63,5 @@ class StringGeneratorTest extends \PHPUnit_Framework_TestCase
             $usedChars[$char]++;
         }
         return $usedChars;
-    }
-
-    /**
-     * @expectedException DomainException
-     */
-    public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
-    {
-        $generator = new StringGenerator();
-        $generator->shrink(true);
     }
 }

--- a/test/Eris/Generator/SubsetGeneratorTest.php
+++ b/test/Eris/Generator/SubsetGeneratorTest.php
@@ -17,7 +17,7 @@ class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
         $maxSize = ForAll::DEFAULT_MAX_SIZE;
         $subsetSizes = [];
         for ($size = 0; $size < $maxSize; $size++) {
-            $subsetSizes[] = count($this->generator->__invoke($size));
+            $subsetSizes[] = count($this->generator->__invoke($size)->unbox());
         }
 
         $subsetSizeFrequencies = array_count_values($subsetSizes);
@@ -35,7 +35,7 @@ class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testNoRepeatedElementsAreInTheSet()
     {
         for ($size = 0; $size < ForAll::DEFAULT_MAX_SIZE; $size++) {
-            $generated = $this->generator->__invoke($size);
+            $generated = $this->generator->__invoke($size)->unbox();
             $this->assertNoRepeatedElements($generated);
         }
     }
@@ -45,40 +45,38 @@ class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
         $elements = $this->generator->__invoke($this->size);
         $elementsAfterShrink = $this->generator->shrink($elements);
 
-        $this->assertLessThanOrEqual(count($elements), count($elementsAfterShrink));
-        $this->assertNoRepeatedElements($elementsAfterShrink);
+        $this->assertLessThanOrEqual(
+            count($elements->unbox()),
+            count($elementsAfterShrink->unbox())
+        );
+        $this->assertNoRepeatedElements($elementsAfterShrink->unbox());
     }
 
     public function testShrinkEmptySet()
     {
         $elements = $this->generator->__invoke($size = 0);
-        $this->assertEquals(0, count($elements));
-        $this->assertEquals(0, count($this->generator->shrink($elements)));
+        $this->assertEquals(0, count($elements->unbox()));
+        $this->assertEquals(0, count($this->generator->shrink($elements)->unbox()));
     }
 
     public function testContainsElementsWhenElementsAreContainedInTheUniverse()
     {
-        $elements = [
+        $elements = GeneratedValue::fromJustValue([
             $this->universe[0],
             $this->universe[1],
-        ];
+        ]);
         $this->assertTrue($this->generator->contains($elements));
     }
 
     public function testDoesNotContainElementsWhenElementsAreNotContainedInTheUniverse()
     {
         $aString = 'a string';
-        $elements = [$aString, $aString];
-        $this->assertFalse($this->generator->contains(['not in universe']));
-        $this->assertFalse($this->generator->contains([
-            $this->universe[0],
-            'not in universe'
-        ]));
+        $this->assertFalse($this->generator->contains(GeneratedValue::fromJustValue([$aString, $aString])));
     }
 
     public function testContainsAnEmptySet()
     {
-        $this->assertTrue($this->generator->contains([]));
+        $this->assertTrue($this->generator->contains(GeneratedValue::fromJustValue([])));
     }
 
     private function assertNoRepeatedElements($generated)

--- a/test/Eris/Generator/TupleGeneratorTest.php
+++ b/test/Eris/Generator/TupleGeneratorTest.php
@@ -18,7 +18,7 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $generated = $generator($this->size);
 
-        $this->assertSame(2, count($generated));
+        $this->assertSame(2, count($generated->unbox()));
         foreach ($generated as $element) {
             $this->assertTrue(
                 $this->generatorForSingleElement->contains($element)
@@ -44,7 +44,7 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new TupleGenerator([]);
 
-        $this->assertSame([], $generator($this->size));
+        $this->assertSame([], $generator($this->size)->unbox());
     }
 
     public function testContainsGeneratedElements()
@@ -54,10 +54,10 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->generatorForSingleElement,
         ]);
 
-        $tupleThatCanBeGenerated = [
+        $tupleThatCanBeGenerated = GeneratedValue::fromJustValue([
             $this->generatorForSingleElement->__invoke($this->size),
             $this->generatorForSingleElement->__invoke($this->size),
-        ];
+        ]);
 
         $this->assertTrue($generator->contains($tupleThatCanBeGenerated));
     }
@@ -69,35 +69,39 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->generatorForSingleElement,
         ]);
 
-        $elements = [42, 42];
+        $elements = $generator->__invoke($this->size);
         $elementsAfterShrink = $generator->shrink($elements);
 
-        $this->assertTrue($this->generatorForSingleElement->contains($elementsAfterShrink[0]));
-        $this->assertTrue($this->generatorForSingleElement->contains($elementsAfterShrink[1]));
+        $this->assertTrue($this->generatorForSingleElement->contains(
+            GeneratedValue::fromJustValue($elementsAfterShrink->unbox()[0]))
+        );
+        $this->assertTrue($this->generatorForSingleElement->contains(
+            GeneratedValue::fromJustValue($elementsAfterShrink->unbox()[1]))
+        );
 
         $this->assertLessThan(
-            $elements[0] + $elements[1],
-            $elementsAfterShrink[0] + $elementsAfterShrink[1]
+            $elements->unbox()[0] + $elements->unbox()[1],
+            $elementsAfterShrink->unbox()[0] + $elementsAfterShrink->unbox()[1]
         );
     }
 
-    public function testShrinkSomethingAlreadyShrunkToTheMax()
+    public function testDoesNotShrinkSomethingAlreadyShrunkToTheMax()
     {
         $constants = [42, 42];
         $generator = new TupleGenerator($constants);
         $elements = $generator($this->size);
-        $this->assertSame($constants, $elements);
+        $this->assertSame($constants, $elements->unbox());
         $elementsAfterShrink = $generator->shrink($elements);
-        $this->assertSame($constants, $elementsAfterShrink);
+        $this->assertSame($constants, $elementsAfterShrink->unbox());
     }
 
     public function testShrinkNothing()
     {
         $generator = new TupleGenerator([]);
         $elements = $generator($this->size);
-        $this->assertSame([], $elements);
+        $this->assertSame([], $elements->unbox());
         $elementsAfterShrink = $generator->shrink($elements);
-        $this->assertSame([], $elementsAfterShrink);
+        $this->assertSame([], $elementsAfterShrink->unbox());
     }
 
     /**
@@ -109,6 +113,6 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->generatorForSingleElement,
             $this->generatorForSingleElement,
         ]);
-        $generator->shrink([1.0, 25.6]);
+        $generator->shrink(GeneratedValue::fromJustValue([1, 2, 3]));
     }
 }

--- a/test/Eris/Generator/TupleGeneratorTest.php
+++ b/test/Eris/Generator/TupleGeneratorTest.php
@@ -19,9 +19,9 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
         $generated = $generator($this->size);
 
         $this->assertSame(2, count($generated->unbox()));
-        foreach ($generated as $element) {
+        foreach ($generated->unbox() as $element) {
             $this->assertTrue(
-                $this->generatorForSingleElement->contains($element)
+                $this->generatorForSingleElement->contains(GeneratedValue::fromJustValue($element))
             );
         }
     }
@@ -33,9 +33,11 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $generated = $generator($this->size);
 
-        foreach ($generated as $element) {
+        foreach ($generated->unbox() as $element) {
             $this->assertTrue(
-                (new ConstantGenerator($aNonGenerator))->contains($element)
+                (new ConstantGenerator($aNonGenerator))->contains(
+                    GeneratedValue::fromJustValue($element)
+                )
             );
         }
     }

--- a/test/Eris/Generator/VectorGeneratorTest.php
+++ b/test/Eris/Generator/VectorGeneratorTest.php
@@ -20,9 +20,11 @@ class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->vectorGenerator;
         $vector = $generator($this->size);
 
-        $this->assertSame($this->vectorSize, count($vector));
-        foreach ($vector as $element) {
-            $this->assertTrue($this->elementGenerator->contains($element));
+        $this->assertSame($this->vectorSize, count($vector->unbox()));
+        foreach ($vector->unbox() as $element) {
+            $this->assertTrue($this->elementGenerator->contains(
+                GeneratedValue::fromJustValue($element)
+            ));
         }
     }
 
@@ -31,10 +33,10 @@ class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->vectorGenerator;
         $vector = $generator($this->size);
 
-        $previousSum = array_reduce($vector, $this->sum);
+        $previousSum = array_reduce($vector->unbox(), $this->sum);
         for ($i = 0; $i < 15; $i++) {
             $vector = $generator->shrink($vector);
-            $currentSum = array_reduce($vector, $this->sum);
+            $currentSum = array_reduce($vector->unbox(), $this->sum);
             $this->assertLessThanOrEqual($previousSum, $currentSum);
             $previousSum = $currentSum;
         }
@@ -46,13 +48,5 @@ class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
         $vector = $generator($this->size);
 
         $this->assertTrue($this->vectorGenerator->contains($vector));
-    }
-
-    /**
-     * @expectedException DomainException
-     */
-    public function testExceptionWhenTryingToShrinkValuesOutsideOfTheDomain()
-    {
-        $this->vectorGenerator->shrink("twenty");
     }
 }


### PR DESCRIPTION
Taking a look at `test.check`:
https://github.com/clojure/test.check/blob/master/doc/intro.md#fmap
`fmap` allows to apply a function to a Generator to build another Generator.

The original syntax:
```
(gen/sample (gen/fmap set (gen/vector gen/nat)))
;; => (#{} #{1} #{1} #{3} #{0 4} #{1 3 4 5} #{0 6} #{3 4 5 7} #{0 3 4 5 7} #{1 5})
```
Eris version (not the same example but even more complex):
```
            Generator\vector(
                3,  
                Generator\map(
                    function($n) { return $n * 2; },
                    Generator\nat()
                )
            ) 
```
produces a vector of 3 even numbers.

To do this in an object-oriented way the interface of Generators changes to:
```
GeneratedValue __invoke($size);
shrink(GeneratedValue $element);
contains(GeneratedValue $element);
```

`GeneratedValue` is a Value Object containing the current `value` generated and the `input` coming from inner Generators. Higher-order generators work mostly with the `value` while shrinking and `contains()` work on `input`.
For example, `Generator\map` shrinks the `input` of the applied function. This also has the potential to simplify some shrink() methods because any information can be encoded in the `input` instead of having to be deduced just from `value`.
Another example is `Generator\frequency` which becomes simpler too, since it can annotate the `GeneratedValue` with the index of the generator originating that value, so that it can choose it again during shrinking.

This is exactly what Clojure's `test.check` does, except that in PHP it's more idiomatic to do it with objects. This is the graph of a single `GeneratedValue`, keeping track from where it comes from:
```
Eris\Generator\GeneratedValue::__set_state(array(                                                                                                           [1181/10314]
   'value' => 
  array (
    0 => 24,
    1 => 28,
    2 => 14,
  ),
   'input' => 
  array (
    0 => 
    Eris\Generator\GeneratedValue::__set_state(array(
       'value' => 24,
       'input' => 
      Eris\Generator\GeneratedValue::__set_state(array(
         'value' => 12,
         'input' => 12,
         'generatorName' => 'integer',
         'annotations' => 
        array (
        ),
      )),
       'generatorName' => 'map',
       'annotations' => 
      array (
      ),
    )),
    1 => 
    Eris\Generator\GeneratedValue::__set_state(array(
       'value' => 28,
       'input' => 
      Eris\Generator\GeneratedValue::__set_state(array(
         'value' => 14,
         'input' => 14,
         'generatorName' => 'integer',
         'annotations' => 
        array (
        ),
      )),
       'generatorName' => 'map',
       'annotations' => 
      array (
      ),
    )),
    ...
```

The name of the Generator is `map` and not `fmap` for idiomatic reasons too, to remind of `array_map`.