### PR TITLE
bind() generator

### DIFF
--- a/examples/BindTest.php
+++ b/examples/BindTest.php
@@ -5,24 +5,22 @@ class BindTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
-    public function testApplyingAFunctionToGeneratedValues()
+    public function testCreatingAnOuterGeneratorFromAGeneratedValue()
     {
-        $sequenceGenerator = Generator\seq(Generator\nat());
         $this->forAll(
             Generator\bind(
-                $sequenceGenerator,
-                function($sequence) {
-                    $sequence = array_merge($sequence, [0]);
+                Generator\vector(4, Generator\nat()),
+                function($vector) {
                     return Generator\tuple(
-                        Generator\elements($sequence),
-                        Generator\constant($sequence)
+                        Generator\elements($vector),
+                        Generator\constant($vector)
                     );
                 }
             )
         )
             ->then(function($tuple) {
-                list ($element, $sequence) = $tuple;
-                $this->assertContains($element, $sequence);
+                list ($element, $vector) = $tuple;
+                $this->assertContains($element, $vector);
             });
     }
 }

--- a/examples/BindTest.php
+++ b/examples/BindTest.php
@@ -12,6 +12,7 @@ class BindTest extends PHPUnit_Framework_TestCase
             Generator\bind(
                 $sequenceGenerator,
                 function($sequence) {
+                    $sequence = array_merge($sequence, [0]);
                     return Generator\tuple(
                         Generator\elements($sequence),
                         Generator\constant($sequence)

--- a/examples/BindTest.php
+++ b/examples/BindTest.php
@@ -1,0 +1,27 @@
+<?php
+use Eris\Generator;
+
+class BindTest extends PHPUnit_Framework_TestCase
+{
+    use Eris\TestTrait;
+
+    public function testApplyingAFunctionToGeneratedValues()
+    {
+        $sequenceGenerator = Generator\seq(Generator\nat());
+        $this->forAll(
+            Generator\bind(
+                $sequenceGenerator,
+                function($sequence) {
+                    return Generator\tuple(
+                        Generator\elements($sequence),
+                        Generator\constant($sequence)
+                    );
+                }
+            )
+        )
+            ->then(function($tuple) {
+                list ($element, $sequence) = $tuple;
+                $this->assertContains($element, $sequence);
+            });
+    }
+}

--- a/examples/BindTest.php
+++ b/examples/BindTest.php
@@ -5,7 +5,7 @@ class BindTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
-    public function testCreatingAnOuterGeneratorFromAGeneratedValue()
+    public function testCreatingABrandNewGeneratorFromAGeneratedValue()
     {
         $this->forAll(
             Generator\bind(

--- a/examples/BindTest.php
+++ b/examples/BindTest.php
@@ -23,4 +23,7 @@ class BindTest extends PHPUnit_Framework_TestCase
                 $this->assertContains($element, $vector);
             });
     }
+
+    // TODO: multiple generators means multiple values passed to the
+    // outer Generator factory
 }

--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -5,7 +5,7 @@ class MapTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
-    public function _testApplyingAFunctionToGeneratedValues()
+    public function testApplyingAFunctionToGeneratedValues()
     {
         $this->forAll(
             Generator\vector(

--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -5,7 +5,7 @@ class MapTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
-    public function testApplyingAFunctionToGeneratedValues()
+    public function _testApplyingAFunctionToGeneratedValues()
     {
         $this->forAll(
             Generator\vector(

--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -63,4 +63,6 @@ class MapTest extends PHPUnit_Framework_TestCase
                 );
             });
     }
+
+    // TODO: multiple generators means multiple values passed to map
 }

--- a/src/Eris/Generator/BindGenerator.php
+++ b/src/Eris/Generator/BindGenerator.php
@@ -3,15 +3,30 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 
-function bind($value, callable $generatorFactory)
+function bind(Generator $originalGenerator, callable $generatorFactory)
 {
-    return new BindGenerator();
+    return new BindGenerator(
+        $originalGenerator,
+        $generatorFactory
+    );
 }
 
 class BindGenerator implements Generator
 {
+    private $originalGenerator;
+    private $generatorFactory;
+    
+    public function __construct($originalGenerator, $generatorFactory)
+    {
+        $this->originalGenerator = $originalGenerator;
+        $this->generatorFactory = $generatorFactory;
+    }
+
     public function __invoke($size)
     {
+        $value = $this->originalGenerator->__invoke($size);
+        $newGenerator = call_user_func($this->generatorFactory, $value->unbox());
+        return $newGenerator->__invoke($size);
     }
 
     public function shrink(GeneratedValue $element){}

--- a/src/Eris/Generator/BindGenerator.php
+++ b/src/Eris/Generator/BindGenerator.php
@@ -1,0 +1,20 @@
+<?php
+namespace Eris\Generator;
+
+use Eris\Generator;
+
+function bind($value, callable $generatorFactory)
+{
+    return new BindGenerator();
+}
+
+class BindGenerator implements Generator
+{
+    public function __invoke($size)
+    {
+    }
+
+    public function shrink(GeneratedValue $element){}
+
+    public function contains(GeneratedValue $element){}
+}

--- a/src/Eris/Generator/BindGenerator.php
+++ b/src/Eris/Generator/BindGenerator.php
@@ -53,5 +53,10 @@ class BindGenerator implements Generator
         );
     }
 
-    public function contains(GeneratedValue $element){}
+    public function contains(GeneratedValue $element)
+    {
+        list ($newGeneratorValue, $originalGeneratorValue) = $element->input();
+        $newGenerator = call_user_func($this->generatorFactory, $originalGeneratorValue->unbox());
+        return $newGenerator->contains($newGeneratorValue);
+    }
 }

--- a/src/Eris/Generator/BindGenerator.php
+++ b/src/Eris/Generator/BindGenerator.php
@@ -24,12 +24,34 @@ class BindGenerator implements Generator
 
     public function __invoke($size)
     {
-        $value = $this->originalGenerator->__invoke($size);
-        $newGenerator = call_user_func($this->generatorFactory, $value->unbox());
-        return $newGenerator->__invoke($size);
+        $originalGeneratorValue = $this->originalGenerator->__invoke($size);
+        $newGenerator = call_user_func($this->generatorFactory, $originalGeneratorValue->unbox());
+        $newGeneratorValue = $newGenerator->__invoke($size);
+        return GeneratedValue::fromValueAndInput(
+            $newGeneratorValue->unbox(),
+            [
+                $newGeneratorValue,
+                $originalGeneratorValue,
+            ],
+            'bind'
+        );
     }
 
-    public function shrink(GeneratedValue $element){}
+    public function shrink(GeneratedValue $element)
+    {
+        list ($newGeneratorValue, $originalGeneratorValue) = $element->input();
+        // TODO: shrink also the second generator
+        $newGenerator = call_user_func($this->generatorFactory, $originalGeneratorValue->unbox());
+        $shrinkedNewGeneratorValue = $newGenerator->shrink($newGeneratorValue);
+        return GeneratedValue::fromValueAndInput(
+            $shrinkedNewGeneratorValue->unbox(),
+            [
+                $shrinkedNewGeneratorValue,
+                $originalGeneratorValue,
+            ],
+            'bind'
+        );
+    }
 
     public function contains(GeneratedValue $element){}
 }

--- a/src/Eris/Generator/ConstantGenerator.php
+++ b/src/Eris/Generator/ConstantGenerator.php
@@ -5,6 +5,10 @@ use Eris\Generator;
 use DomainException;
 use InvalidArgumentException;
 
+function constant($value) {
+    return ConstantGenerator::box($value);
+}
+
 class ConstantGenerator implements Generator
 {
     private $value;

--- a/src/Eris/TestTrait.php
+++ b/src/Eris/TestTrait.php
@@ -107,6 +107,7 @@ trait TestTrait
         } elseif ($arguments[0] instanceof Generator) {
             $generators = $arguments;
         } else {
+            // TODO: drop the 1-argument array support
             $generators = $arguments[0];
         }
         $quantifier = new Quantifier\ForAll(

--- a/test/Eris/Generator/BindGeneratorTest.php
+++ b/test/Eris/Generator/BindGeneratorTest.php
@@ -42,4 +42,45 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertLessThanOrEqual(5, $value->unbox());
     }
+
+    public function testAssociativeProperty()
+    {
+        $firstGenerator = new BindGenerator(
+            new BindGenerator(
+                new ChooseGenerator(0, 5),
+                function($n) {
+                    return new ChooseGenerator($n * 10, $n * 10 + 1);
+                }
+            ),
+            function($m) {
+                return new VectorGenerator($m, new IntegerGenerator());
+            }
+        );
+        $secondGenerator = new BindGenerator(
+            new ChooseGenerator(0, 5),
+            function($n) {
+                return new BindGenerator(
+                    new ChooseGenerator($n * 10, $n * 10 + 1),
+                    function($m) {
+                        return new VectorGenerator($m, new IntegerGenerator());
+                    }
+                );
+            }
+        );
+        for ($i = 0; $i < 100; $i++) {
+            $this->assertIsAnArrayOfX0OrX1Elements($firstGenerator->__invoke($this->size)->unbox());
+            $this->assertIsAnArrayOfX0OrX1Elements($secondGenerator->__invoke($this->size)->unbox());
+        }
+    }
+
+    private function assertIsAnArrayOfX0OrX1Elements(array $value)
+    {
+        $this->assertTrue(
+            in_array(
+                count($value) % 10,
+                [0, 1]
+            ),
+            "The array has " . count($value) . " elements"
+        );
+    }
 }

--- a/test/Eris/Generator/BindGeneratorTest.php
+++ b/test/Eris/Generator/BindGeneratorTest.php
@@ -22,4 +22,23 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
             $generator->__invoke($this->size)->unbox()
         );
     }
+
+    public function testShrinksTheValue()
+    {
+        $generator = new BindGenerator(
+            new ChooseGenerator(0, 5),
+            function($n) {
+                return new ChooseGenerator($n, $n + 10);
+            }
+        );
+        $value = $generator->__invoke($this->size);
+        for ($i = 0; $i < 20; $i++) {
+            $this->assertInternalType(
+                'integer',
+                $value->unbox()
+            );
+            $value = $generator->shrink($value);
+        }
+        $this->assertEquals(0, $value->unbox());
+    }
 }

--- a/test/Eris/Generator/BindGeneratorTest.php
+++ b/test/Eris/Generator/BindGeneratorTest.php
@@ -23,7 +23,7 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testShrinksTheValue()
+    public function testShrinksTheOuterGenerator()
     {
         $generator = new BindGenerator(
             new ChooseGenerator(0, 5),
@@ -37,8 +37,9 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
                 'integer',
                 $value->unbox()
             );
+            $this->assertTrue($generator->contains($value), "Element $value should be contained in the Generator");
             $value = $generator->shrink($value);
         }
-        $this->assertEquals(0, $value->unbox());
+        $this->assertLessThanOrEqual(5, $value->unbox());
     }
 }

--- a/test/Eris/Generator/BindGeneratorTest.php
+++ b/test/Eris/Generator/BindGeneratorTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Eris\Generator;
+
+class BindGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->size = 10;
+    }
+    
+    public function testGeneratesAGeneratedValueObject()
+    {
+        $generator = new BindGenerator(
+            // TODO: order of parameters should be consistent with map, or not?
+            ConstantGenerator::box(4),
+            function($n) {
+                return new ChooseGenerator($n, $n+10);
+            }
+        );
+        $this->assertInternalType(
+            'integer',
+            $generator->__invoke($this->size)->unbox()
+        );
+    }
+}


### PR DESCRIPTION
Ported from
https://github.com/clojure/test.check/blob/master/doc/intro.md

Means we can use a random value to build a completely new Generator, instead of just applying a pure function to the output. The example builds an outer Generator which selects a random element from a vector, which cannot be done with `map`.
