### PR TITLE
Removing support for array of generators in forAll()

### DIFF
--- a/examples/CharacterTest.php
+++ b/examples/CharacterTest.php
@@ -14,9 +14,9 @@ class CharacterTest extends PHPUnit_Framework_TestCase
 
     public function testLengthOfAsciiCharactersInPhp()
     {
-        $this->forAll([
-            Generator\char(['basic-latin']),
-        ])
+        $this->forAll(
+            Generator\char(['basic-latin'])
+        )
             ->then(function($char) {
                 $this->assertLenghtIs1($char);
             });
@@ -24,9 +24,9 @@ class CharacterTest extends PHPUnit_Framework_TestCase
 
     public function testLengthOfPrintableAsciiCharacters()
     {
-        $this->forAll([
-            Generator\char(['basic-latin']),
-        ])
+        $this->forAll(
+            Generator\char(['basic-latin'])
+        )
             ->when(is\printableCharacter())
             ->then(function($char) {
                 $this->assertFalse(ord($char) < 32);
@@ -35,10 +35,10 @@ class CharacterTest extends PHPUnit_Framework_TestCase
 
     public function testMultiplePrintableCharacters()
     {
-        $this->forAll([
+        $this->forAll(
             Generator\char(['basic-latin']),
-            Generator\char(['basic-latin']),
-        ])
+            Generator\char(['basic-latin'])
+        )
             ->when(are\printableCharacters())
             ->then(function($first, $second) {
                 $this->assertFalse(ord($first) < 32);

--- a/examples/DateTest.php
+++ b/examples/DateTest.php
@@ -7,9 +7,9 @@ class DateTest extends PHPUnit_Framework_TestCase
 
     public function testYearOfADate()
     {
-        $this->forAll([
-            Generator\date("2014-01-01T00:00:00", "2014-12-31T23:59:59"),
-        ])
+        $this->forAll(
+            Generator\date("2014-01-01T00:00:00", "2014-12-31T23:59:59")
+        )
             ->then(function(DateTime $date) {
                 $this->assertEquals(
                     "2014",
@@ -20,9 +20,9 @@ class DateTest extends PHPUnit_Framework_TestCase
 
     public function testDefaultValuesForTheInterval()
     {
-        $this->forAll([
-            Generator\date(),
-        ])
+        $this->forAll(
+            Generator\date()
+        )
             ->then(function(DateTime $date) {
                 $this->assertGreaterThanOrEqual(
                     "1970",

--- a/examples/FrequencyTest.php
+++ b/examples/FrequencyTest.php
@@ -8,13 +8,13 @@ class FrequencyTest extends \PHPUnit_Framework_TestCase
     public function testFalsyValues()
     {
         $this
-            ->forAll([
+            ->forAll(
                 Generator\frequency([
                     [8, false],
                     [4, 0],
                     [4, ''],
                 ])
-            ])
+            )
             ->then(function($falsyValue) {
                 $this->assertFalse((bool) $falsyValue);
             });
@@ -23,13 +23,13 @@ class FrequencyTest extends \PHPUnit_Framework_TestCase
     public function testAlwaysFails()
     {
         $this
-            ->forAll([
+            ->forAll(
                 Generator\frequency([
                     [8, Generator\nat(1, 100)],
                     [4, Generator\nat(100, 200)],
                     [4, Generator\nat(200, 300)],
                 ])
-            ])
+            )
             ->then(function($element) {
                 // Expected to shrunk always to 1
                 $this->assertEquals(0, $element);

--- a/examples/RegexTest.php
+++ b/examples/RegexTest.php
@@ -10,9 +10,9 @@ class RegexTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringsMatchingAParticularRegex()
     {
-        $this->forAll([
-            Generator\regex("[a-z]{10}"),
-        ])
+        $this->forAll(
+            Generator\regex("[a-z]{10}")
+        )
             ->then(function($string) {
                 $this->assertEquals(10, strlen($string));
             });

--- a/examples/ShrinkingTest.php
+++ b/examples/ShrinkingTest.php
@@ -8,9 +8,9 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
 
     public function testShrinkingRespectsAntecedents()
     {
-        $this->forAll([
-                Generator\choose(0, 20),
-            ])
+        $this->forAll(
+                Generator\choose(0, 20)
+            )
             ->when(function($number) {
                 return $number > 10;
             })

--- a/examples/ShrinkingTimeLimitTest.php
+++ b/examples/ShrinkingTimeLimitTest.php
@@ -21,10 +21,10 @@ class ShrinkingTimeLimitTest extends PHPUnit_Framework_TestCase
 
     public function testLengthPreservation()
     {
-        $this->forAll([
+        $this->forAll(
             Generator\string(),
-            Generator\string(),
-        ])
+            Generator\string()
+        )
             ->then(function($first, $second) {
                 $result = very_slow_concatenation($first, $second);
                 $this->assertEquals(

--- a/src/Eris/TestTrait.php
+++ b/src/Eris/TestTrait.php
@@ -97,18 +97,10 @@ trait TestTrait
 
     /**
      * forAll($generator1, $generator2, ...)
-     * forAll([$generator1, $generator2, ...])
      */
     protected function forAll()
     {
-        $arguments = func_get_args();
-        if (count($arguments) > 1) {
-            $generators = $arguments;
-        } elseif ($arguments[0] instanceof Generator) {
-            $generators = $arguments;
-        } else {
-            $generators = $arguments[0];
-        }
+        $generators = func_get_args();
         $quantifier = new Quantifier\ForAll(
             $generators,
             $this->iterations,


### PR DESCRIPTION
It's an old and ugly syntax