### PR TITLE
when() and suchThat() unification

### DIFF
--- a/docs/generators/composite.rst
+++ b/docs/generators/composite.rst
@@ -107,6 +107,8 @@ Such That allows a Generator's output to be filtered, excluding values that to d
 
 ``testFilterSyntax`` shows the ``Generator\filter()`` syntax, which is just an alias for ``Generator\suchThat()``. The order of the parameters requires to pass the callable first, for consistency with ``Generator\map()`` and in opposition to ``array_filter``.
 
+``testSuchThatAcceptsPHPUnitConstraints`` shows that you can pass in PHPUnit constraints in lieu of callables, in the same way as they are passed to ``assertThat()``, or to ``with()`` when defining PHPUnit mock expectations.
+
 ``testSuchThatShrinkingRespectsTheCondition`` shows that shrinking takes into account the callable and stops when it is not satisfied anymore. Therefore, this test will fail for all numbers lower than or equal to 100, but the minimum example found is 43 as it's the smallest and simplest value that still satisfied the condition.
 
 .. code-block:: bash

--- a/examples/SuchThatTest.php
+++ b/examples/SuchThatTest.php
@@ -37,6 +37,24 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
             ->then($this->allNumbersAreBiggerThan(42));
     }
 
+    public function testSuchThatAcceptsPHPUnitConstraints()
+    {
+        $this->forAll(
+            Generator\vector(
+                5,
+                Generator\suchThat(
+                    $this->isType('integer'),
+                    Generator\oneOf(
+                        Generator\choose(0, 1000),
+                        Generator\string()
+                    )
+                )
+            )
+        )
+            ->then($this->allNumbersAreBiggerThan(42));
+    }
+
+
     public function testSuchThatShrinkingRespectsTheCondition()
     {
         $this->forAll(

--- a/examples/SuchThatTest.php
+++ b/examples/SuchThatTest.php
@@ -7,77 +7,82 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
 
     public function testSuchThatBuildsANewGeneratorFilteringTheInnerOne()
     {
-        $this->forAll(
-            Generator\vector(
-                5,
-                Generator\suchThat(
-                    function($n) {
-                        return $n > 42;
-                    },
-                    Generator\choose(0, 1000)
+        $this
+            ->forAll(
+                Generator\vector(
+                    5,
+                    Generator\suchThat(
+                        function($n) {
+                            return $n > 42;
+                        },
+                        Generator\choose(0, 1000)
+                    )
                 )
             )
-        )
             ->then($this->allNumbersAreBiggerThan(42));
     }
 
     public function testFilterSyntax()
     {
-        $this->forAll(
-            Generator\vector(
-                5,
-                Generator\filter(
-                    function($n) {
-                        return $n > 42;
-                    },
-                    Generator\choose(0, 1000)
+        $this
+            ->forAll(
+                Generator\vector(
+                    5,
+                    Generator\filter(
+                        function($n) {
+                            return $n > 42;
+                        },
+                        Generator\choose(0, 1000)
+                    )
                 )
             )
-        )
             ->then($this->allNumbersAreBiggerThan(42));
     }
 
     public function testSuchThatAcceptsPHPUnitConstraints()
     {
-        $this->forAll(
-            Generator\vector(
-                5,
-                Generator\suchThat(
-                    $this->isType('integer'),
-                    Generator\oneOf(
-                        Generator\choose(0, 1000),
-                        Generator\string()
+        $this
+            ->forAll(
+                Generator\vector(
+                    5,
+                    Generator\suchThat(
+                        $this->isType('integer'),
+                        Generator\oneOf(
+                            Generator\choose(0, 1000),
+                            Generator\string()
+                        )
                     )
                 )
             )
-        )
             ->then($this->allNumbersAreBiggerThan(42));
     }
 
 
     public function testSuchThatShrinkingRespectsTheCondition()
     {
-        $this->forAll(
-            Generator\suchThat(
-                function($n) {
-                    return $n > 42;
-                },
-                Generator\choose(0, 1000)
+        $this
+            ->forAll(
+                Generator\suchThat(
+                    function($n) {
+                        return $n > 42;
+                    },
+                    Generator\choose(0, 1000)
+                )
             )
-        )
             ->then($this->numberIsBiggerThan(100));
     }
 
     public function testSuchThatShrinkingRespectsTheConditionButTriesToSkipOverTheNotAllowedSet()
     {
-        $this->forAll(
-            Generator\suchThat(
-                function($n) {
-                    return $n <> 42;
-                },
-                Generator\choose(0, 1000)
+        $this
+            ->forAll(
+                Generator\suchThat(
+                    function($n) {
+                        return $n <> 42;
+                    },
+                    Generator\choose(0, 1000)
+                )
             )
-        )
             ->then($this->numberIsBiggerThan(100));
     }
 

--- a/src/Eris/Generator/SuchThatGenerator.php
+++ b/src/Eris/Generator/SuchThatGenerator.php
@@ -10,18 +10,18 @@ use PHPUnit_Framework_ExpectationFailedException;
  * @param callable|PHPUnit_Framework_Constraint $filter
  * @return SuchThatGenerator
  */
-function filter($filter, Generator $generator)
+function filter($filter, Generator $generator, $maximumAttempts = 100)
 {
-    return suchThat($filter, $generator);
+    return suchThat($filter, $generator, $maximumAttempts);
 }
 
 /**
  * @param callable|PHPUnit_Framework_Constraint $filter
  * @return SuchThatGenerator
  */
-function suchThat($filter, Generator $generator)
+function suchThat($filter, Generator $generator, $maximumAttempts = 100)
 {
-    return new SuchThatGenerator($filter, $generator);
+    return new SuchThatGenerator($filter, $generator, $maximumAttempts);
 }
 
 class SuchThatGenerator implements Generator
@@ -33,11 +33,11 @@ class SuchThatGenerator implements Generator
     /**
      * @param callable|PHPUnit_Framework_Constraint
      */
-    public function __construct($filter, $generator)
+    public function __construct($filter, $generator, $maximumAttempts = 100)
     {
         $this->filter = $filter;
         $this->generator = $generator;
-        $this->maximumAttempts = 10;
+        $this->maximumAttempts = $maximumAttempts;
     }
 
     public function __invoke($size)

--- a/src/Eris/Generator/SuchThatGenerator.php
+++ b/src/Eris/Generator/SuchThatGenerator.php
@@ -83,10 +83,12 @@ class SuchThatGenerator implements Generator
             } catch (PHPUnit_Framework_ExpectationFailedException $e) {
                 return false;
             }
-        } else if (is_callable($this->filter)) {
+        } 
+
+        if (is_callable($this->filter)) {
             return call_user_func($this->filter, $value->unbox());
-        } else {
-            throw new LogicException("Specified filter does not seem to be of the correct type. Please pass a callable or a PHPUnit_Framework_Constraint instead of " . var_export($this->filter, true));
-        }
+        } 
+
+        throw new LogicException("Specified filter does not seem to be of the correct type. Please pass a callable or a PHPUnit_Framework_Constraint instead of " . var_export($this->filter, true));
     }
 }

--- a/test/Eris/ExampleEnd2EndTest.php
+++ b/test/Eris/ExampleEnd2EndTest.php
@@ -152,10 +152,14 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
     public function testSuchThatTest()
     {
         $this->runExample('SuchThatTest.php');
-        $this->assertTestsAreFailing(2);
+        $this->assertTestsAreFailing(3);
         $this->assertRegexp(
             '/number was asserted to be more than 100, but it\'s 43/',
             (string) $this->theTest('testSuchThatShrinkingRespectsTheCondition')->failure
+        );
+        $this->assertRegexp(
+            '/number was asserted to be more than 42, but it\'s 0/',
+            (string) $this->theTest('testSuchThatAcceptsPHPUnitConstraints')->failure
         );
         $this->assertRegexp(
             '/number was asserted to be more than 100, but it\'s 0/',

--- a/test/Eris/Generator/SuchThatGeneratorTest.php
+++ b/test/Eris/Generator/SuchThatGeneratorTest.php
@@ -20,6 +20,18 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAcceptsPHPUnitConstraints()
+    {
+        $generator = new SuchThatGenerator(
+            $this->callback(function($n) { return $n % 2 == 0; }),
+            ConstantGenerator::box(10)
+        );
+        $this->assertEquals(
+            10,
+            $generator->__invoke($this->size)->unbox()
+        );
+    }
+
     public function testShrinksTheOriginalInput()
     {
         $generator = new SuchThatGenerator(

--- a/test/Eris/Generator/SuchThatGeneratorTest.php
+++ b/test/Eris/Generator/SuchThatGeneratorTest.php
@@ -14,7 +14,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
             function($n) { return $n % 2 == 0; },
             ConstantGenerator::box(10)
         );
-        $this->assertEquals(
+        $this->assertSame(
             10,
             $generator->__invoke($this->size)->unbox()
         );
@@ -26,7 +26,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->callback(function($n) { return $n % 2 == 0; }),
             ConstantGenerator::box(10)
         );
-        $this->assertEquals(
+        $this->assertSame(
             10,
             $generator->__invoke($this->size)->unbox()
         );
@@ -46,7 +46,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
                 "Every shrunk element should still be contained: " . var_export($element, true)
             );
             $this->assertTrue(
-                $element->unbox() % 2 == 0,
+                $element->unbox() % 2 === 0,
                 "Element should still be filtered while shrinking: " . var_export($element, true)
             );
         }

--- a/test/Eris/Generator/SuchThatGeneratorTest.php
+++ b/test/Eris/Generator/SuchThatGeneratorTest.php
@@ -67,10 +67,10 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGivesUpShrinkingIfTheFilterIsNotSatisfiedTooManyTimes()
     {
         $generator = new SuchThatGenerator(
-            function($n) { return $n % 25 == 0; },
-            new ChooseGenerator(0, 100)
+            function($n) { return $n % 250 == 0; },
+            new ChooseGenerator(0, 1000)
         );
-        $unshrinkable = GeneratedValue::fromJustValue(47);
+        $unshrinkable = GeneratedValue::fromJustValue(470);
         $this->assertEquals(
             $unshrinkable,
             $generator->shrink($unshrinkable)


### PR DESCRIPTION
With this change we support PHPUnit constraints in suchThat().

However now there are two duplicate functionalities:
- `suchThat()` Generator (https://github.com/giorgiosironi/eris/blob/master/examples/SuchThatTest.php)
- `when()` call on objects returned by `forAll()` (https://github.com/giorgiosironi/eris/blob/master/examples/WhenTest.php)
both supporting callables and PHPUnit constraints.

Given that `suchThat()` has more power, as its filtering result can be passed to other Generators. So I propose to either:
- remove `when()`
- implement `when()` in terms of `suchThat()`, by wrapping the Generators in a `tuple()`; keeps backward compatibility. Unsure whether to document `when()` and officially support it or not.