### PR TITLE
Fix: Simplify test bootstrapping

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<phpunit bootstrap="test/.bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="Full">
             <directory>./test</directory>
@@ -10,5 +10,7 @@
     </testsuites>
     <php>
         <ini name="display_errors" value="1" />
+        <ini name="display_startup_errors" value="1" />
+        <ini name="error_reporting" value="E_ALL" />
     </php>
 </phpunit>

--- a/test/.bootstrap.php
+++ b/test/.bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-ini_set('error_reporting', E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
-require_once(__DIR__ . '/../vendor/autoload.php');


### PR DESCRIPTION
This PR

* [x] simplifies the test bootstrapping

:information_desk_person: We can specify all of the values in `phpunit.xml`, right?