### PR TITLE
Fix: Improve Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
 language: php
+
+sudo: false
+
 php:
   - 5.5
   - 5.6
   - 7.0
   - hhvm
-before_script: "composer install"
-script: "vendor/bin/phpunit test"
-sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - composer self-update
+  - composer config github-oauth.github.com $GITHUB_TOKEN
+
+install:
+  - composer install --prefer-dist
+
+script:
+  - vendor/bin/phpunit test
+
 notifications:
   webhooks:
     urls:
@@ -14,4 +30,3 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
-


### PR DESCRIPTION
This PR 

* [x] improves the configuration for Travis

:information_desk_person: Specifically, here's what this suggests

* add vertical whitespace for enhanced legibility
* move sections around and using more appropriate sections
* update composer itself before installing dependencies
* attempt to authenticate with the GitHub API using an environment variable `GITHUB_TOKEN`
* enable caching for dependencies as installed with composer to speed up the build
* disable xdebug as it is not needed, but speeds up the build 
* installing dependencies with `--prefer-dist` to help caching dependencies

@giorgiosironi 

If by any chance you could provide a GitHub token as an environment variable `GITHUB_TOKEN` at https://travis-ci.org/giorgiosironi/eris/settings, that would be great, helps with authenticating against the GitHub API.