### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/examples/CharacterTest.php
+++ b/examples/CharacterTest.php
@@ -7,7 +7,7 @@ class CharacterTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->minimumEvaluationRatio = 0.2;
     }

--- a/test/Eris/Generator/AssociativeArrayGeneratorTest.php
+++ b/test/Eris/Generator/AssociativeArrayGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class AssociativeArrayGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->letterGenerator = ElementsGenerator::fromArray(['A', 'B', 'C']);
         $this->cipherGenerator = ElementsGenerator::fromArray([0, 1, 2]);

--- a/test/Eris/Generator/BindGeneratorTest.php
+++ b/test/Eris/Generator/BindGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class BindGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/CharacterGeneratorTest.php
+++ b/test/Eris/Generator/CharacterGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 0;
     }

--- a/test/Eris/Generator/ChooseGeneratorTest.php
+++ b/test/Eris/Generator/ChooseGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 0; // ignored by this kind of generator
     }

--- a/test/Eris/Generator/ConstantGeneratorTest.php
+++ b/test/Eris/Generator/ConstantGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class ConstantGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 0;
     }

--- a/test/Eris/Generator/DateGeneratorTest.php
+++ b/test/Eris/Generator/DateGeneratorTest.php
@@ -4,7 +4,7 @@ use DateTime;
 
 class DateGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/ElementsGeneratorTest.php
+++ b/test/Eris/Generator/ElementsGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class ElementsGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/FloatGeneratorTest.php
+++ b/test/Eris/Generator/FloatGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class FloatGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 300;
     }

--- a/test/Eris/Generator/FrequencyGeneratorTest.php
+++ b/test/Eris/Generator/FrequencyGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class FrequencyGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/IntegerGeneratorTest.php
+++ b/test/Eris/Generator/IntegerGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/MapGeneratorTest.php
+++ b/test/Eris/Generator/MapGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class MapGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/OneOfGeneratorTest.php
+++ b/test/Eris/Generator/OneOfGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class OneOfGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->singleElementGenerator = new ChooseGenerator(0, 100);
         $this->size = 10;

--- a/test/Eris/Generator/RegexGeneratorTest.php
+++ b/test/Eris/Generator/RegexGeneratorTest.php
@@ -15,7 +15,7 @@ class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/SequenceGeneratorTest.php
+++ b/test/Eris/Generator/SequenceGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class SequenceGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 100;
         $this->singleElementGenerator = new ChooseGenerator(10, 100);

--- a/test/Eris/Generator/SetGeneratorTest.php
+++ b/test/Eris/Generator/SetGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class SetGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 100;
         $this->singleElementGenerator = new ChooseGenerator(10, 100);

--- a/test/Eris/Generator/SubsetGeneratorTest.php
+++ b/test/Eris/Generator/SubsetGeneratorTest.php
@@ -5,7 +5,7 @@ use Eris\Quantifier\ForAll;
 
 class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->universe = ['a', 'b', 'c', 'd', 'e'];
         $this->generator = new SubsetGenerator($this->universe);

--- a/test/Eris/Generator/SuchThatGeneratorTest.php
+++ b/test/Eris/Generator/SuchThatGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->size = 10;
     }

--- a/test/Eris/Generator/TupleGeneratorTest.php
+++ b/test/Eris/Generator/TupleGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->generatorForSingleElement = new ChooseGenerator(0, 100);
         $this->size = 10;

--- a/test/Eris/Generator/VectorGeneratorTest.php
+++ b/test/Eris/Generator/VectorGeneratorTest.php
@@ -3,7 +3,7 @@ namespace Eris\Generator;
 
 class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->vectorSize = rand(5, 10);
         $this->size = 10;

--- a/test/Eris/Listener/LogTest.php
+++ b/test/Eris/Listener/LogTest.php
@@ -3,7 +3,7 @@ namespace Eris\Listener;
 
 class LogTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->file = '/tmp/eris-log-unit-test.log';
         $this->time = function() {

--- a/test/Eris/Quantifier/TimeBasedTerminationConditionTest.php
+++ b/test/Eris/Quantifier/TimeBasedTerminationConditionTest.php
@@ -5,7 +5,7 @@ use DateInterval;
 
 class TimeBasedTerminationConditionTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->time = function() {
             return $this->currentTime;


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` to `protected`

:information_desk_person: This is the visibility as defined on the the parent, no need to increase it.
