### PR TITLE
Fix: Declare namespaced functions in separate files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
     "autoload": {
         "psr-0": {"" : "src/"},
         "files": [
-          "src/Eris/Generator/functions.php"
+            "src/Eris/Antecedent/functions.php",
+            "src/Eris/Generator/functions.php",
+            "src/Eris/Listener/functions.php"
         ]
     }
 }

--- a/src/Eris/Antecedent/PrintableCharacter.php
+++ b/src/Eris/Antecedent/PrintableCharacter.php
@@ -3,16 +3,6 @@ namespace Eris\Antecedent;
 
 use Eris\Antecedent;
 
-function printableCharacter()
-{
-    return new PrintableCharacter();
-}
-
-function printableCharacters()
-{
-    return new PrintableCharacter();
-}
-
 class PrintableCharacter implements Antecedent
 {
     /**

--- a/src/Eris/Antecedent/functions.php
+++ b/src/Eris/Antecedent/functions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Eris\Antecedent;
+
+function printableCharacter()
+{
+    return new PrintableCharacter();
+}
+
+function printableCharacters()
+{
+    return new PrintableCharacter();
+}

--- a/src/Eris/Generator/AssociativeArrayGenerator.php
+++ b/src/Eris/Generator/AssociativeArrayGenerator.php
@@ -3,14 +3,6 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 
-/**
- * @return AssociativeArrayGenerator
- */
-function associative(array $generators)
-{
-    return new AssociativeArrayGenerator($generators);
-}
-
 class AssociativeArrayGenerator implements Generator
 {
     private $generators;

--- a/src/Eris/Generator/BindGenerator.php
+++ b/src/Eris/Generator/BindGenerator.php
@@ -3,14 +3,6 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 
-function bind(Generator $innerGenerator, callable $outerGeneratorFactory)
-{
-    return new BindGenerator(
-        $innerGenerator,
-        $outerGeneratorFactory
-    );
-}
-
 class BindGenerator implements Generator
 {
     private $innerGenerator;

--- a/src/Eris/Generator/BooleanGenerator.php
+++ b/src/Eris/Generator/BooleanGenerator.php
@@ -4,11 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-function bool()
-{
-    return new BooleanGenerator();
-}
-
 class BooleanGenerator implements Generator
 {
     public function __invoke($_size)

--- a/src/Eris/Generator/CharacterGenerator.php
+++ b/src/Eris/Generator/CharacterGenerator.php
@@ -4,18 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 
 /**
- * Generates character in the ASCII 0-127 range.
- *
- * @param array $characterSets  Only supported charset: "basic-latin"
- * @param string $encoding  Only supported encoding: "utf-8"
- * @return Generator\CharacterGenerator
- */
-function char(array $characterSets = ['basic-latin'], $encoding = 'utf-8')
-{
-    return CharacterGenerator::ascii();
-}
-
-/**
  * Generates character in the ASCII 32-127 range, excluding non-printable ones
  * or modifiers such as CR, LF and Tab.
  *

--- a/src/Eris/Generator/ChooseGenerator.php
+++ b/src/Eris/Generator/ChooseGenerator.php
@@ -9,20 +9,6 @@ if (!defined('ERIS_PHP_INT_MIN')) {
     define('ERIS_PHP_INT_MIN', ~PHP_INT_MAX);
 }
 
-/**
- * Generates a number in the range from the lower bound to the upper bound,
- * inclusive. The result shrinks towards smaller absolute values.
- * The order of the parameters does not care since they are re-ordered by the
- * generator itself.
- *
- * @param $x int One of the 2 boundaries of the range
- * @param $y int The other boundary of the range
- * @return Generator\ChooseGenerator
- */
-function choose($lowerLimit, $upperLimit) {
-    return new ChooseGenerator($lowerLimit, $upperLimit);
-}
-
 class ChooseGenerator implements Generator
 {
     private $lowerLimit;

--- a/src/Eris/Generator/ConstantGenerator.php
+++ b/src/Eris/Generator/ConstantGenerator.php
@@ -4,15 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-/**
- * @param mixed $value  the only value to generate
- * @return ConstantGenerator
- */
-function constant($value)
-{
-    return ConstantGenerator::box($value);
-}
-
 class ConstantGenerator implements Generator
 {
     private $value;

--- a/src/Eris/Generator/DateGenerator.php
+++ b/src/Eris/Generator/DateGenerator.php
@@ -5,29 +5,6 @@ use Eris\Generator;
 use DateTime;
 use DomainException;
 
-function date($lowerLimit = null, $upperLimit = null)
-{
-    $box = function($date) {
-        if ($date === null) {
-            return $date;
-        }
-        if ($date instanceof DateTime) {
-            return $date;
-        }
-        return new DateTime($date);
-    };
-    $withDefault = function($value, $default) {
-        if ($value !== null) {
-            return $value;
-        }
-        return $default;
-    };
-    return new DateGenerator(
-        $withDefault($box($lowerLimit), new DateTime("@0")),
-        $withDefault($box($upperLimit), new DateTime("@" . getrandmax()))
-    );
-}
-
 class DateGenerator implements Generator
 {
     private $lowerLimit;

--- a/src/Eris/Generator/ElementsGenerator.php
+++ b/src/Eris/Generator/ElementsGenerator.php
@@ -4,17 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-function elements(/*$a, $b, ...*/)
-{
-    $arguments = func_get_args();
-    if (count($arguments) == 1) {
-        return Generator\ElementsGenerator::fromArray($arguments[0]);
-    } else {
-        return Generator\ElementsGenerator::fromArray($arguments);
-    }
-}
-
-
 class ElementsGenerator implements Generator
 {
     private $domain;

--- a/src/Eris/Generator/FloatGenerator.php
+++ b/src/Eris/Generator/FloatGenerator.php
@@ -4,11 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-function float()
-{
-    return new FloatGenerator();
-}
-
 class FloatGenerator implements Generator
 {
     public function __construct()

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -5,14 +5,6 @@ use Eris\Generator;
 use DomainException;
 use InvalidArgumentException;
 
-/**
- * @return FrequencyGenerator
- */
-function frequency(/*$frequencyAndGenerator, $frequencyAndGenerator, ...*/)
-{
-    return new FrequencyGenerator(func_get_args());
-}
-
 class FrequencyGenerator implements Generator
 {
     private $generators;

--- a/src/Eris/Generator/IntegerGenerator.php
+++ b/src/Eris/Generator/IntegerGenerator.php
@@ -4,50 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-/**
- * Generates a positive or negative integer (with absolute value bounded by
- * the generation size).
- */
-function int()
-{
-    return new IntegerGenerator();
-}
-
-/**
- * Generates a positive integer (bounded by the generation size).
- */
-function pos()
-{
-    $mustBeStrictlyPositive = function($n) {
-        return abs($n) + 1;
-    };
-    return new IntegerGenerator($mustBeStrictlyPositive);
-}
-
-function nat()
-{
-    $mustBeNatural = function($n) {
-        return abs($n);
-    };
-    return new IntegerGenerator($mustBeNatural);
-}
-
-/**
- * Generates a negative integer (bounded by the generation size).
- */
-function neg()
-{
-    $mustBeStrictlyNegative = function($n) {
-        return (-1) * (abs($n) + 1);
-    };
-    return new IntegerGenerator($mustBeStrictlyNegative);
-}
-
-function byte()
-{
-    return new ChooseGenerator(0, 255);
-}
-
 class IntegerGenerator implements Generator
 {
     private $mapFn;

--- a/src/Eris/Generator/MapGenerator.php
+++ b/src/Eris/Generator/MapGenerator.php
@@ -3,12 +3,6 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 
-// TODO: support calls like ($function . $generator)
-function map(callable $function, Generator $generator)
-{
-    return new MapGenerator($function, $generator);
-}
-
 class MapGenerator implements Generator
 {
     private $map;

--- a/src/Eris/Generator/NamesGenerator.php
+++ b/src/Eris/Generator/NamesGenerator.php
@@ -3,11 +3,6 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 
-function names()
-{
-    return NamesGenerator::defaultDataSet();
-}
-
 class NamesGenerator implements Generator
 {
     private $list;

--- a/src/Eris/Generator/OneOfGenerator.php
+++ b/src/Eris/Generator/OneOfGenerator.php
@@ -3,14 +3,6 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 
-/**
- * @return OneOfGenerator
- */
-function oneOf(/*$a, $b, ...*/)
-{
-    return new OneOfGenerator(func_get_args());
-}
-
 class OneOfGenerator implements Generator
 {
     private $generator;

--- a/src/Eris/Generator/RegexGenerator.php
+++ b/src/Eris/Generator/RegexGenerator.php
@@ -8,19 +8,6 @@ use ReverseRegex\Random\SimpleRandom;
 use ReverseRegex\Parser;
 use ReverseRegex\Generator\Scope;
 
-/**
- * Note * and + modifiers cause an unbounded number of character to be generated
- * (up to plus infinity) and as such they are not supported.
- * Please use {1,N} and {0,N} instead of + and *.
- *
- * @param string $expression
- * @return Generator\RegexGenerator
- */
-function regex($expression)
-{
-    return new RegexGenerator($expression);
-}
-
 class RegexGenerator implements Generator
 {
     private $expression;

--- a/src/Eris/Generator/SequenceGenerator.php
+++ b/src/Eris/Generator/SequenceGenerator.php
@@ -4,15 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-function seq(Generator $singleElementGenerator)
-{
-    // TODO: Generator::box($singleElementGenerator);
-    if (!($singleElementGenerator instanceof Generator)) {
-        $singleElementGenerator = new Constant($singleElementGenerator);
-    }
-    return new SequenceGenerator($singleElementGenerator);
-}
-
 class SequenceGenerator implements Generator
 {
     private $singleElementGenerator;

--- a/src/Eris/Generator/SetGenerator.php
+++ b/src/Eris/Generator/SetGenerator.php
@@ -4,15 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-/**
- * @param Generator $singleElementGenerator
- * @return SetGenerator
- */
-function set($singleElementGenerator)
-{
-    return new SetGenerator($singleElementGenerator);
-}
-
 class SetGenerator implements Generator
 {
     private $singleElementGenerator;

--- a/src/Eris/Generator/StringGenerator.php
+++ b/src/Eris/Generator/StringGenerator.php
@@ -4,11 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-function string()
-{
-    return new StringGenerator();
-}
-
 class StringGenerator implements Generator
 {
     public function __invoke($size)

--- a/src/Eris/Generator/SubsetGenerator.php
+++ b/src/Eris/Generator/SubsetGenerator.php
@@ -6,15 +6,6 @@ namespace Eris\Generator;
 use Eris\Quantifier\ForAll;
 use Eris\Generator;
 
-/**
- * @param array $universe
- * @return SubsetGenerator
- */
-function subset($input)
-{
-    return new SubsetGenerator($input);
-}
-
 class SubsetGenerator implements Generator
 {
     private $universe;

--- a/src/Eris/Generator/SuchThatGenerator.php
+++ b/src/Eris/Generator/SuchThatGenerator.php
@@ -4,22 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use LogicException;
 
-/**
- * @return SuchThatGenerator
- */
-function filter(callable $filter, Generator $generator)
-{
-    return suchThat($filter, $generator);
-}
-
-/**
- * @return SuchThatGenerator
- */
-function suchThat(callable $filter, Generator $generator)
-{
-    return new SuchThatGenerator($filter, $generator);
-}
-
 class SuchThatGenerator implements Generator
 {
     private $filter;

--- a/src/Eris/Generator/TupleGenerator.php
+++ b/src/Eris/Generator/TupleGenerator.php
@@ -4,24 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-/**
- * One Generator for each member of the Tuple:
- * tuple(Generator, Generator, Generator...)
- * Or an array of generators:
- * tuple(array $generators)
- * @return Generator\TupleGenerator
- */
-function tuple()
-{
-    $arguments = func_get_args();
-    if (is_array($arguments[0])) {
-        $generators = $arguments[0];
-    } else {
-        $generators = $arguments;
-    }
-    return new TupleGenerator($generators);
-}
-
 class TupleGenerator implements Generator
 {
     private $generators;

--- a/src/Eris/Generator/VectorGenerator.php
+++ b/src/Eris/Generator/VectorGenerator.php
@@ -4,11 +4,6 @@ namespace Eris\Generator;
 use Eris\Generator;
 use DomainException;
 
-function vector($size, Generator $elementsGenerator)
-{
-    return new VectorGenerator($size, $elementsGenerator);
-}
-
 class VectorGenerator implements Generator
 {
     private $generator;

--- a/src/Eris/Generator/functions.php
+++ b/src/Eris/Generator/functions.php
@@ -1,6 +1,7 @@
 <?php
 namespace Eris\Generator;
 
+use DateTime;
 use Eris\Generator;
 
 function ensureAreAllGenerators(array $generators)
@@ -14,4 +15,253 @@ function ensureIsGenerator($generator)
         return $generator;
     }
     return new ConstantGenerator($generator);
+}
+
+/**
+ * @return AssociativeArrayGenerator
+ */
+function associative(array $generators)
+{
+    return new AssociativeArrayGenerator($generators);
+}
+
+function bind(Generator $innerGenerator, callable $outerGeneratorFactory)
+{
+    return new BindGenerator(
+        $innerGenerator,
+        $outerGeneratorFactory
+    );
+}
+
+function bool()
+{
+    return new BooleanGenerator();
+}
+
+/**
+ * Generates character in the ASCII 0-127 range.
+ *
+ * @param array $characterSets  Only supported charset: "basic-latin"
+ * @param string $encoding  Only supported encoding: "utf-8"
+ * @return Generator\CharacterGenerator
+ */
+function char(array $characterSets = ['basic-latin'], $encoding = 'utf-8')
+{
+    return CharacterGenerator::ascii();
+}
+
+/**
+ * Generates a number in the range from the lower bound to the upper bound,
+ * inclusive. The result shrinks towards smaller absolute values.
+ * The order of the parameters does not care since they are re-ordered by the
+ * generator itself.
+ *
+ * @param $x int One of the 2 boundaries of the range
+ * @param $y int The other boundary of the range
+ * @return Generator\ChooseGenerator
+ */
+function choose($lowerLimit, $upperLimit) {
+    return new ChooseGenerator($lowerLimit, $upperLimit);
+}
+
+/**
+ * @param mixed $value  the only value to generate
+ * @return ConstantGenerator
+ */
+function constant($value)
+{
+    return ConstantGenerator::box($value);
+}
+
+function date($lowerLimit = null, $upperLimit = null)
+{
+    $box = function($date) {
+        if ($date === null) {
+            return $date;
+        }
+        if ($date instanceof DateTime) {
+            return $date;
+        }
+        return new DateTime($date);
+    };
+    $withDefault = function($value, $default) {
+        if ($value !== null) {
+            return $value;
+        }
+        return $default;
+    };
+    return new DateGenerator(
+        $withDefault($box($lowerLimit), new DateTime("@0")),
+        $withDefault($box($upperLimit), new DateTime("@" . getrandmax()))
+    );
+}
+
+function elements(/*$a, $b, ...*/)
+{
+    $arguments = func_get_args();
+    if (count($arguments) == 1) {
+        return Generator\ElementsGenerator::fromArray($arguments[0]);
+    } else {
+        return Generator\ElementsGenerator::fromArray($arguments);
+    }
+}
+
+function float()
+{
+    return new FloatGenerator();
+}
+
+/**
+ * @return FrequencyGenerator
+ */
+function frequency(/*$frequencyAndGenerator, $frequencyAndGenerator, ...*/)
+{
+    return new FrequencyGenerator(func_get_args());
+}
+
+/**
+ * Generates a positive or negative integer (with absolute value bounded by
+ * the generation size).
+ */
+function int()
+{
+    return new IntegerGenerator();
+}
+
+/**
+ * Generates a positive integer (bounded by the generation size).
+ */
+function pos()
+{
+    $mustBeStrictlyPositive = function($n) {
+        return abs($n) + 1;
+    };
+    return new IntegerGenerator($mustBeStrictlyPositive);
+}
+
+function nat()
+{
+    $mustBeNatural = function($n) {
+        return abs($n);
+    };
+    return new IntegerGenerator($mustBeNatural);
+}
+
+/**
+ * Generates a negative integer (bounded by the generation size).
+ */
+function neg()
+{
+    $mustBeStrictlyNegative = function($n) {
+        return (-1) * (abs($n) + 1);
+    };
+    return new IntegerGenerator($mustBeStrictlyNegative);
+}
+
+function byte()
+{
+    return new ChooseGenerator(0, 255);
+}
+
+// TODO: support calls like ($function . $generator)
+function map(callable $function, Generator $generator)
+{
+    return new MapGenerator($function, $generator);
+}
+
+function names()
+{
+    return NamesGenerator::defaultDataSet();
+}
+
+/**
+ * @return OneOfGenerator
+ */
+function oneOf(/*$a, $b, ...*/)
+{
+    return new OneOfGenerator(func_get_args());
+}
+
+/**
+ * Note * and + modifiers cause an unbounded number of character to be generated
+ * (up to plus infinity) and as such they are not supported.
+ * Please use {1,N} and {0,N} instead of + and *.
+ *
+ * @param string $expression
+ * @return Generator\RegexGenerator
+ */
+function regex($expression)
+{
+    return new RegexGenerator($expression);
+}
+
+function seq(Generator $singleElementGenerator)
+{
+    // TODO: Generator::box($singleElementGenerator);
+    if (!($singleElementGenerator instanceof Generator)) {
+        $singleElementGenerator = new Constant($singleElementGenerator);
+    }
+    return new SequenceGenerator($singleElementGenerator);
+}
+
+/**
+ * @param Generator $singleElementGenerator
+ * @return SetGenerator
+ */
+function set($singleElementGenerator)
+{
+    return new SetGenerator($singleElementGenerator);
+}
+
+function string()
+{
+    return new StringGenerator();
+}
+
+/**
+ * @param array $universe
+ * @return SubsetGenerator
+ */
+function subset($input)
+{
+    return new SubsetGenerator($input);
+}
+
+/**
+ * @return SuchThatGenerator
+ */
+function filter(callable $filter, Generator $generator)
+{
+    return suchThat($filter, $generator);
+}
+
+/**
+ * @return SuchThatGenerator
+ */
+function suchThat(callable $filter, Generator $generator)
+{
+    return new SuchThatGenerator($filter, $generator);
+}
+
+/**
+ * One Generator for each member of the Tuple:
+ * tuple(Generator, Generator, Generator...)
+ * Or an array of generators:
+ * tuple(array $generators)
+ * @return Generator\TupleGenerator
+ */
+function tuple()
+{
+    $arguments = func_get_args();
+    if (is_array($arguments[0])) {
+        $generators = $arguments[0];
+    } else {
+        $generators = $arguments;
+    }
+    return new TupleGenerator($generators);
+}
+
+function vector($size, Generator $elementsGenerator)
+{
+    return new VectorGenerator($size, $elementsGenerator);
 }

--- a/src/Eris/Listener/CollectFrequencies.php
+++ b/src/Eris/Listener/CollectFrequencies.php
@@ -4,11 +4,6 @@ namespace Eris\Listener;
 use Eris\Listener;
 use InvalidArgumentException;
 
-function collectFrequencies(callable $collectFunction = null) 
-{
-    return new CollectFrequencies($collectFunction);
-}
-
 class CollectFrequencies
     extends EmptyListener
     implements Listener

--- a/src/Eris/Listener/Log.php
+++ b/src/Eris/Listener/Log.php
@@ -3,11 +3,6 @@ namespace Eris\Listener;
 
 use Eris\Listener;
 
-function log($file)
-{
-    return new Log($file, 'time', getmypid());
-}
-
 class Log
     extends EmptyListener
     implements Listener

--- a/src/Eris/Listener/functions.php
+++ b/src/Eris/Listener/functions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Eris\Listener;
+
+function collectFrequencies(callable $collectFunction = null)
+{
+    return new CollectFrequencies($collectFunction);
+}
+
+function log($file)
+{
+    return new Log($file, 'time', getmypid());
+}

--- a/src/Eris/TestTrait.php
+++ b/src/Eris/TestTrait.php
@@ -47,36 +47,6 @@ trait TestTrait
     }
 
     /**
-     * @beforeClass
-     */
-    public static function loadAllErisGenerators()
-    {
-        foreach(glob(__DIR__ . '/Generator/*.php') as $filename) {
-            require_once($filename);
-        }
-    }
-
-    /**
-     * @beforeClass
-     */
-    public static function loadAllErisAntecedents()
-    {
-        foreach(glob(__DIR__ . '/Antecedent/*.php') as $filename) {
-            require_once($filename);
-        }
-    }
-
-    /**
-     * @beforeClass
-     */
-    public static function loadAllErisListeners()
-    {
-        foreach(glob(__DIR__ . '/Listener/*.php') as $filename) {
-            require_once($filename);
-        }
-    }
-
-    /**
      * @after
      */
     public function checkConstraintsHaveNotSkippedTooManyIterations()


### PR DESCRIPTION
This PR

* [x] moves declaration of namespace functions to separate files
* [x] updates composer autoloading configuration
* [x] removes `glob`ing to load files

:information_desk_person: A few have already been declared in [`src/Eris/Generator/functions.php`](https://github.com/giorgiosironi/eris/blob/master/src/Eris/Generator/functions.php), and autoloading configuration is already provided in [composer.json](https://github.com/giorgiosironi/eris/blob/master/composer.json#L33), so why not take it a step further and remove some unneccessary code?