### PR TITLE
Fix: Validate composer.json on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer config github-oauth.github.com $GITHUB_TOKEN
+  - composer validate
 
 install:
   - composer install --prefer-dist


### PR DESCRIPTION
This PR

* [x] runs `composer validate` in the `before_install` section on Travis

:information_desk_person: This helps spotting issues with `composer.son`. For reference, see https://getcomposer.org/doc/03-cli.md#validate.

Running this on current `master`:

```
$ composer validate

./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
Defining autoload.psr-0 with an empty namespace prefix is a bad idea for performance
```

