### PR TITLE
Fix: Specify namespace prefix for PSR-0 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         "icomefromthenet/reverse-regex": "v0.0.6.3 for the regex() Generator"
     },
     "autoload": {
-        "psr-0": {"" : "src/"},
+        "psr-0": {
+            "Eris" : "src/"
+        },
         "files": [
           "src/Eris/Generator/functions.php"
         ]


### PR DESCRIPTION
This PR

* [x] specifies a namespace prefix for PSR-0 autoloading

Related to #77.
Alternative to #76.