### PR TITLE
Fix: Declare fields otherwise declared dynamically

### DIFF
--- a/src/Eris/Generator/AssociativeArrayGenerator.php
+++ b/src/Eris/Generator/AssociativeArrayGenerator.php
@@ -14,7 +14,8 @@ function associative(array $generators)
 class AssociativeArrayGenerator implements Generator
 {
     private $generators;
-    
+    private $tupleGenerator;
+
     public function __construct(array $generators)
     {
         $this->generators = $generators;

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -16,6 +16,7 @@ function frequency(/*$frequencyAndGenerator, $frequencyAndGenerator, ...*/)
 class FrequencyGenerator implements Generator
 {
     private $generators;
+    private $frequencies;
 
     public function __construct(array $generatorsWithFrequency)
     {

--- a/src/Eris/Generator/TupleGenerator.php
+++ b/src/Eris/Generator/TupleGenerator.php
@@ -26,6 +26,7 @@ class TupleGenerator implements Generator
 {
     private $generators;
     private $size;
+    private $numberOfGenerators;
 
     public function __construct(array $generators)
     {

--- a/src/Eris/Listener/Log.php
+++ b/src/Eris/Listener/Log.php
@@ -13,6 +13,7 @@ class Log
     implements Listener
 {
     private $file;
+    private $fp;
     private $time;
     private $pid;
 

--- a/src/Eris/Quantifier/Evaluation.php
+++ b/src/Eris/Quantifier/Evaluation.php
@@ -11,6 +11,7 @@ final class Evaluation
     private $assertion;
     private $onFailure;
     private $onSuccess;
+    private $values;
 
     public static function of($assertion)
     {

--- a/src/Eris/Quantifier/TimeBasedTerminationCondition.php
+++ b/src/Eris/Quantifier/TimeBasedTerminationCondition.php
@@ -11,6 +11,7 @@ class TimeBasedTerminationCondition
     implements TerminationCondition, Listener
 {
     private $limitTime;
+    private $time;
     private $maximumInterval;
 
     public function __construct(callable $time, DateInterval $maximumInterval)


### PR DESCRIPTION
This PR

* [x] declares fields which are otherwise declared dynamically