### PR TITLE
Enhancement: Add Composer script for simplifying running tests locally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
         "files": [
           "src/Eris/Generator/functions.php"
         ]
+    },
+    "scripts": {
+        "test": "composer validate --no-check-lock && composer update && vendor/bin/phpunit test"
     }
 }


### PR DESCRIPTION
This PR

* [x] adds a composer script to simplify running tests locally

:information_desk_person: This would come in handy, too, if we want to start using `php-cs-fixer`!

Run

```
$ composer test
```

to run all the things.