### PR TITLE
Enhancement: Run php-cs-fixer on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
+.php_cs.cache
 composer.lock
 docs/_build

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,9 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()->in(__DIR__);
+
+return Symfony\CS\Config\Config::create()
+    ->setUsingCache(true)
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->finder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ env:
   global:
     - secure: "Vbdts9k+dvnzAmuRPXMDZLw2+s+4q0Ijdbx97rCBefrBbG+6elfR0ao60135QVAoiQxTR//Iz6ZZbsFfTTt9Qo4SVvulzepuLz4lDQmO1BTeKlAWyM650+uFDP39iRY+i6Z7w5RGZzw4F3Sjw8N4kcxdrkkJLH4p9ZQkA5uSkzg="
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.5
+    - php: 5.6
+      env: WITH_CS=true
+    - php: 7
+    - php: hhvm
 
 cache:
   directories:
@@ -27,6 +30,7 @@ install:
 
 script:
   - vendor/bin/phpunit test
+  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run; fi
 
 notifications:
   webhooks:

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         ]
     },
     "scripts": {
+        "cs": "composer validate --no-check-lock && composer update && vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff",
         "test": "composer validate --no-check-lock && composer update && vendor/bin/phpunit test"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "phpunit/phpunit": ">4,<6"
     },
     "require-dev": {
+        "fabpot/php-cs-fixer": "^1.11.2",
         "icomefromthenet/reverse-regex": "v0.0.6.3"
     },
     "suggest":

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,15 @@
         ]
     },
     "scripts": {
-        "cs": "composer validate --no-check-lock && composer update && vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff",
-        "test": "composer validate --no-check-lock && composer update && vendor/bin/phpunit test"
+        "cs": [
+            "composer validate --no-check-lock",
+            "composer update",
+            "vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff"
+        ],
+        "test": [
+            "composer validate --no-check-lock",
+            "composer update",
+            "vendor/bin/phpunit test"
+        ]
     }
 }

--- a/examples/AssociativeArrayTest.php
+++ b/examples/AssociativeArrayTest.php
@@ -13,7 +13,7 @@ class AssociativeArrayTest extends PHPUnit_Framework_TestCase
                 'cipher' => Generator\choose(0, 9),
             ])
         )
-            ->then(function($array) {
+            ->then(function ($array) {
                 $this->assertEquals(2, count($array));
                 $letter = $array['letter'];
                 $this->assertInternalType('string', $letter);

--- a/examples/BindTest.php
+++ b/examples/BindTest.php
@@ -10,7 +10,7 @@ class BindTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\bind(
                 Generator\vector(4, Generator\nat()),
-                function($vector) {
+                function ($vector) {
                     return Generator\tuple(
                         Generator\elements($vector),
                         Generator\constant($vector)
@@ -18,8 +18,8 @@ class BindTest extends PHPUnit_Framework_TestCase
                 }
             )
         )
-            ->then(function($tuple) {
-                list ($element, $vector) = $tuple;
+            ->then(function ($tuple) {
+                list($element, $vector) = $tuple;
                 $this->assertContains($element, $vector);
             });
     }

--- a/examples/BooleanTest.php
+++ b/examples/BooleanTest.php
@@ -11,7 +11,7 @@ class BooleanTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\bool()
         )
-            ->then(function($boolValue) {
+            ->then(function ($boolValue) {
                 $this->assertTrue(
                     ($boolValue === true || $boolValue === false),
                     "$boolValue is not true nor false"

--- a/examples/CharacterTest.php
+++ b/examples/CharacterTest.php
@@ -17,7 +17,7 @@ class CharacterTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\char(['basic-latin'])
         )
-            ->then(function($char) {
+            ->then(function ($char) {
                 $this->assertLenghtIs1($char);
             });
     }
@@ -28,7 +28,7 @@ class CharacterTest extends PHPUnit_Framework_TestCase
             Generator\char(['basic-latin'])
         )
             ->when(is\printableCharacter())
-            ->then(function($char) {
+            ->then(function ($char) {
                 $this->assertFalse(ord($char) < 32);
             });
     }
@@ -40,7 +40,7 @@ class CharacterTest extends PHPUnit_Framework_TestCase
             Generator\char(['basic-latin'])
         )
             ->when(are\printableCharacters())
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $this->assertFalse(ord($first) < 32);
                 $this->assertFalse(ord($second) < 32);
             });

--- a/examples/ChooseTest.php
+++ b/examples/ChooseTest.php
@@ -12,7 +12,7 @@ class ChooseTest extends PHPUnit_Framework_TestCase
             Generator\choose(-1000, 430),
             Generator\choose(230, -30000)
         )
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $x = $first + $second;
                 $y = $second + $first;
                 $this->assertEquals(

--- a/examples/CollectTest.php
+++ b/examples/CollectTest.php
@@ -12,7 +12,7 @@ class CollectTest extends PHPUnit_Framework_TestCase
         $this
             ->forAll(Generator\neg())
             ->hook(Listener\collectFrequencies())
-            ->then(function($x) {
+            ->then(function ($x) {
                 $this->assertTrue($x < $x + 1);
             });
     }
@@ -25,7 +25,7 @@ class CollectTest extends PHPUnit_Framework_TestCase
                 Generator\char()
             )
             ->hook(Listener\collectFrequencies())
-            ->then(function($vector) {
+            ->then(function ($vector) {
                 $this->assertEquals(2, count($vector));
             });
     }
@@ -37,10 +37,10 @@ class CollectTest extends PHPUnit_Framework_TestCase
                 Generator\seq(Generator\nat())
             )
             ->withMaxSize(10)
-            ->hook(Listener\collectFrequencies(function($array) {
+            ->hook(Listener\collectFrequencies(function ($array) {
                 return count($array);
             }))
-            ->then(function($array) {
+            ->then(function ($array) {
                 $this->assertEquals(count($array), count(array_reverse($array)));
             });
     }

--- a/examples/ConstantTest.php
+++ b/examples/ConstantTest.php
@@ -13,7 +13,7 @@ class ConstantTest extends \PHPUnit_Framework_TestCase
                 Generator\nat(),
                 Generator\constant(2)
             )
-            ->then(function($number, $alwaysTwo) {
+            ->then(function ($number, $alwaysTwo) {
                 $this->assertTrue(($number * $alwaysTwo % 2) === 0);
             });
     }
@@ -25,7 +25,7 @@ class ConstantTest extends \PHPUnit_Framework_TestCase
                 Generator\nat(),
                 2
             )
-            ->then(function($number, $alwaysTwo) {
+            ->then(function ($number, $alwaysTwo) {
                 $this->assertTrue(($number * $alwaysTwo % 2) === 0);
             });
     }

--- a/examples/DateTest.php
+++ b/examples/DateTest.php
@@ -10,7 +10,7 @@ class DateTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\date("2014-01-01T00:00:00", "2014-12-31T23:59:59")
         )
-            ->then(function(DateTime $date) {
+            ->then(function (DateTime $date) {
                 $this->assertEquals(
                     "2014",
                     $date->format('Y')
@@ -23,7 +23,7 @@ class DateTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\date()
         )
-            ->then(function(DateTime $date) {
+            ->then(function (DateTime $date) {
                 $this->assertGreaterThanOrEqual(
                     "1970",
                     $date->format('Y')
@@ -42,7 +42,7 @@ class DateTest extends PHPUnit_Framework_TestCase
             Generator\choose(0, 364),
             Generator\choose(0, 364)
         )
-        ->then(function($year, $dayOfYear, $anotherDayOfYear) {
+        ->then(function ($year, $dayOfYear, $anotherDayOfYear) {
             $day = fromZeroBasedDayOfYear($year, $dayOfYear);
             $anotherDay = fromZeroBasedDayOfYear($year, $anotherDayOfYear);
             $this->assertEquals(

--- a/examples/DisableShrinkingTest.php
+++ b/examples/DisableShrinkingTest.php
@@ -17,10 +17,9 @@ class DisableShrinkingTest extends \PHPUnit_Framework_TestCase
                 Generator\nat()
             )
             ->disableShrinking()
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->calls++;
                 $this->assertTrue(false, "Total calls: {$this->calls}");
             });
- 
     }
 }

--- a/examples/ElementsTest.php
+++ b/examples/ElementsTest.php
@@ -10,7 +10,7 @@ class ElementsTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\elements(1, 2, 3)
         )
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertContains(
                     $number,
                     [1, 2, 3]
@@ -28,7 +28,7 @@ class ElementsTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\elements([1, 2, 3])
         )
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertContains(
                     $number,
                     [1, 2, 3]
@@ -44,9 +44,9 @@ class ElementsTest extends \PHPUnit_Framework_TestCase
                 Generator\elements([2, 4, 6, 8, 10, 12])
             )
         )
-            ->then(function($vector) {
+            ->then(function ($vector) {
                 $sum = array_sum($vector);
-                $isEven = function($number) { return $number % 2 == 0; };
+                $isEven = function ($number) { return $number % 2 == 0; };
                 $this->assertTrue(
                     $isEven($sum),
                     "$sum is not even, but it's the sum of the vector " . var_export($vector, true)

--- a/examples/ErrorTest.php
+++ b/examples/ErrorTest.php
@@ -10,7 +10,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\string()
         )
-            ->then(function($string) {
+            ->then(function ($string) {
                 throw new RuntimeException("Something like a missing array index happened.");
             });
     }

--- a/examples/FloatTest.php
+++ b/examples/FloatTest.php
@@ -8,7 +8,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
     public function testAPropertyHoldingForAllNumbers()
     {
         $this->forAll(Generator\float())
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertEquals(
                     0.0,
                     abs($number) - abs($number)
@@ -19,7 +19,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
     public function testAPropertyHoldingOnlyForPositiveNumbers()
     {
         $this->forAll(Generator\float())
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue(
                     $number >= 0,
                     "$number is not a (loosely) positive number"

--- a/examples/FrequencyTest.php
+++ b/examples/FrequencyTest.php
@@ -15,7 +15,7 @@ class FrequencyTest extends \PHPUnit_Framework_TestCase
                     [4, '']
                 )
             )
-            ->then(function($falsyValue) {
+            ->then(function ($falsyValue) {
                 $this->assertFalse((bool) $falsyValue);
             });
     }
@@ -30,7 +30,7 @@ class FrequencyTest extends \PHPUnit_Framework_TestCase
                     [4, Generator\choose(200, 300)]
                 )
             )
-            ->then(function($element) {
+            ->then(function ($element) {
                 $this->assertEquals(0, $element);
             });
     }

--- a/examples/IntegerTest.php
+++ b/examples/IntegerTest.php
@@ -12,7 +12,7 @@ class IntegerTest extends PHPUnit_Framework_TestCase
             Generator\int(),
             Generator\int()
         )
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $x = $first + $second;
                 $y = $second + $first;
                 $this->assertEquals(
@@ -30,7 +30,7 @@ class IntegerTest extends PHPUnit_Framework_TestCase
             Generator\neg(),
             Generator\pos()
         )
-            ->then(function($first, $second, $third) {
+            ->then(function ($first, $second, $third) {
                 $x = $first + ($second + $third);
                 $y = ($first + $second) + $third;
                 $this->assertEquals(
@@ -46,7 +46,7 @@ class IntegerTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\byte()
         )
-            ->then(function($byte) {
+            ->then(function ($byte) {
                 $this->assertTrue(
                     $byte >= 0 && $byte <= 255,
                     "$byte is not a valid value for a byte"

--- a/examples/LimitToTest.php
+++ b/examples/LimitToTest.php
@@ -12,7 +12,7 @@ class LimitToTest extends PHPUnit_Framework_TestCase
              ->forAll(
                 Generator\int()
             )
-            ->then(function($value) {
+            ->then(function ($value) {
                 $this->assertInternalType('integer', $value);
             });
     }
@@ -40,7 +40,7 @@ class LimitToTest extends PHPUnit_Framework_TestCase
              ->forAll(
                 Generator\int()
             )
-            ->then(function($value) {
+            ->then(function ($value) {
                 usleep(100 * 1000);
                 $this->assertTrue(true);
             });

--- a/examples/LogFileTest.php
+++ b/examples/LogFileTest.php
@@ -13,9 +13,8 @@ class LogFileTest extends PHPUnit_Framework_TestCase
             Generator\int()
         )
             ->hook(Listener\log('/tmp/eris-log-file-test.log'))
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertInternalType('integer', $number);
             });
     }
 }
-

--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -11,12 +11,12 @@ class MapTest extends PHPUnit_Framework_TestCase
             Generator\vector(
                 3,
                 Generator\map(
-                    function($n) { return $n * 2; },
+                    function ($n) { return $n * 2; },
                     Generator\nat()
                 )
             )
         )
-            ->then(function($tripleOfEvenNumbers) {
+            ->then(function ($tripleOfEvenNumbers) {
                 foreach ($tripleOfEvenNumbers as $number) {
                     $this->assertTrue(
                         $number % 2 == 0,
@@ -30,11 +30,11 @@ class MapTest extends PHPUnit_Framework_TestCase
     {
         $this->forAll(
             Generator\map(
-                function($n) { return $n * 2; },
+                function ($n) { return $n * 2; },
                 Generator\nat()
             )
         )
-            ->then(function($evenNumber) {
+            ->then(function ($evenNumber) {
                 $this->assertLessThanOrEqual(
                     100,
                     $evenNumber,
@@ -49,12 +49,12 @@ class MapTest extends PHPUnit_Framework_TestCase
             Generator\vector(
                 3,
                 Generator\map(
-                    function($n) { return $n * 2; },
+                    function ($n) { return $n * 2; },
                     Generator\nat()
                 )
             )
         )
-            ->then(function($tripleOfEvenNumbers) {
+            ->then(function ($tripleOfEvenNumbers) {
                 $this->assertLessThanOrEqual(
                     100,
                     array_sum($tripleOfEvenNumbers),

--- a/examples/NamesTest.php
+++ b/examples/NamesTest.php
@@ -9,7 +9,7 @@ class NamesTest extends PHPUnit_Framework_TestCase
     {
         $this->forAll(
             Generator\names()
-        )->then(function($name) {
+        )->then(function ($name) {
             var_dump($name);
         });
     }

--- a/examples/OneOfTest.php
+++ b/examples/OneOfTest.php
@@ -14,7 +14,7 @@ class OneOfTest extends \PHPUnit_Framework_TestCase
                     Generator\neg()
                 )
             )
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertNotEquals(0, $number);
             });
     }

--- a/examples/ReadmeTest.php
+++ b/examples/ReadmeTest.php
@@ -10,7 +10,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\choose(0, 1000)
         )
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue(
                     $number < 42,
                     "$number is not less than 42 apparently"

--- a/examples/RegexTest.php
+++ b/examples/RegexTest.php
@@ -13,7 +13,7 @@ class RegexTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\regex("[a-z]{10}")
         )
-            ->then(function($string) {
+            ->then(function ($string) {
                 $this->assertEquals(10, strlen($string));
             });
     }

--- a/examples/SequenceTest.php
+++ b/examples/SequenceTest.php
@@ -12,7 +12,7 @@ class SequenceTest extends PHPUnit_Framework_TestCase
             ->forAll(
                 Generator\seq(Generator\nat())
             )
-            ->then(function($array) {
+            ->then(function ($array) {
                 $this->assertEquals(count($array), count(array_reverse($array)));
             });
     }
@@ -23,7 +23,7 @@ class SequenceTest extends PHPUnit_Framework_TestCase
             ->forAll(
                 Generator\seq(Generator\nat())
             )
-            ->then(function($array) {
+            ->then(function ($array) {
                 $this->assertEquals($array, array_reverse(array_reverse($array)));
             });
     }

--- a/examples/SetTest.php
+++ b/examples/SetTest.php
@@ -11,12 +11,11 @@ class SetTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\set(Generator\nat())
         )
-            ->then(function($set) {
+            ->then(function ($set) {
                 $this->assertInternalType('array', $set);
                 foreach ($set as $element) {
                     $this->assertGreaterThanOrEqual(0, $element);
                 }
             });
     }
-
 }

--- a/examples/ShrinkingTest.php
+++ b/examples/ShrinkingTest.php
@@ -11,7 +11,7 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
                 Generator\string()
             )
-            ->then(function($string) {
+            ->then(function ($string) {
                 var_dump($string);
                 $this->assertNotContains('B', $string);
             });
@@ -22,10 +22,10 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
                 Generator\choose(0, 20)
             )
-            ->when(function($number) {
+            ->when(function ($number) {
                 return $number > 10;
             })
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue($number % 29 == 0, "The number $number is not multiple of 29");
             });
     }

--- a/examples/ShrinkingTimeLimitTest.php
+++ b/examples/ShrinkingTimeLimitTest.php
@@ -22,7 +22,7 @@ class ShrinkingTimeLimitTest extends PHPUnit_Framework_TestCase
                 Generator\string(),
                 Generator\string()
             )
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $result = very_slow_concatenation($first, $second);
                 $this->assertEquals(
                     strlen($first) + strlen($second),

--- a/examples/SortTest.php
+++ b/examples/SortTest.php
@@ -11,7 +11,7 @@ class SortTest extends PHPUnit_Framework_TestCase
             ->forAll(
                 Generator\seq(Generator\nat())
             )
-            ->then(function($array) {
+            ->then(function ($array) {
                 sort($array);
                 for ($i = 0; $i < count($array) - 1; $i++) {
                     $this->assertTrue(

--- a/examples/StringTest.php
+++ b/examples/StringTest.php
@@ -18,7 +18,7 @@ class StringTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\string()
         )
-            ->then(function($string) {
+            ->then(function ($string) {
                 $this->assertEquals(
                     $string,
                     string_concatenation($string, ''),
@@ -33,7 +33,7 @@ class StringTest extends PHPUnit_Framework_TestCase
             Generator\string(),
             Generator\string()
         )
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $result = string_concatenation($first, $second);
                 $this->assertEquals(
                     strlen($first) + strlen($second),

--- a/examples/SubsetTest.php
+++ b/examples/SubsetTest.php
@@ -13,7 +13,7 @@ class SubsetTest extends PHPUnit_Framework_TestCase
                 2, 4, 6, 8, 10
             ])
         )
-            ->then(function($set) {
+            ->then(function ($set) {
                 $this->assertInternalType('array', $set);
                 foreach ($set as $element) {
                     $this->assertTrue($this->isEven($element), "Element $element is not even, where did it come from?");

--- a/examples/SuchThatTest.php
+++ b/examples/SuchThatTest.php
@@ -12,7 +12,7 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
                 Generator\vector(
                     5,
                     Generator\suchThat(
-                        function($n) {
+                        function ($n) {
                             return $n > 42;
                         },
                         Generator\choose(0, 1000)
@@ -29,7 +29,7 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
                 Generator\vector(
                     5,
                     Generator\filter(
-                        function($n) {
+                        function ($n) {
                             return $n > 42;
                         },
                         Generator\choose(0, 1000)
@@ -63,7 +63,7 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
         $this
             ->forAll(
                 Generator\suchThat(
-                    function($n) {
+                    function ($n) {
                         return $n > 42;
                     },
                     Generator\choose(0, 1000)
@@ -77,7 +77,7 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
         $this
             ->forAll(
                 Generator\suchThat(
-                    function($n) {
+                    function ($n) {
                         return $n <> 42;
                     },
                     Generator\choose(0, 1000)
@@ -88,7 +88,7 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
 
     public function allNumbersAreBiggerThan($lowerLimit)
     {
-        return function($vector) use ($lowerLimit) {
+        return function ($vector) use ($lowerLimit) {
             foreach ($vector as $number) {
                 $this->assertTrue(
                     $number > $lowerLimit,
@@ -100,7 +100,7 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
 
     public function numberIsBiggerThan($lowerLimit)
     {
-        return function($number) use ($lowerLimit) {
+        return function ($number) use ($lowerLimit) {
             $this->assertTrue(
                 $number > $lowerLimit,
                 "\$number was asserted to be more than $lowerLimit, but it's $number"

--- a/examples/SumTest.php
+++ b/examples/SumTest.php
@@ -18,7 +18,7 @@ class SumTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\nat(1000)
         )
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertEquals(
                     $number,
                     my_sum($number, 0),
@@ -32,7 +32,7 @@ class SumTest extends PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\nat(1000)
         )
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertEquals(
                     $number,
                     my_sum(0, $number),
@@ -47,7 +47,7 @@ class SumTest extends PHPUnit_Framework_TestCase
             Generator\nat(1000),
             Generator\nat(1000)
         )
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $this->assertEquals(
                     $first + $second,
                     my_sum($first, $second),
@@ -62,7 +62,7 @@ class SumTest extends PHPUnit_Framework_TestCase
             Generator\nat(1000),
             Generator\nat(1000)
         )
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $this->assertEquals(
                     -1,
                     my_sum($first, $second),

--- a/examples/TupleTest.php
+++ b/examples/TupleTest.php
@@ -13,7 +13,7 @@ class TupleTest extends PHPUnit_Framework_TestCase
                 Generator\choose(0, 9)
             )
         )
-            ->then(function($tuple) {
+            ->then(function ($tuple) {
                 $letter = $tuple[0];
                 $cipher = $tuple[1];
                 $this->assertEquals(

--- a/examples/VectorTest.php
+++ b/examples/VectorTest.php
@@ -11,7 +11,7 @@ class VectorTest extends PHPUnit_Framework_TestCase
             Generator\vector(10, Generator\nat(1000)),
             Generator\vector(10, Generator\nat(1000))
         )
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $concatenated = array_merge($first, $second);
                 $this->assertEquals(
                     count($concatenated),

--- a/examples/WhenTest.php
+++ b/examples/WhenTest.php
@@ -10,10 +10,10 @@ class WhenTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\choose(0, 1000)
         )
-            ->when(function($n) {
+            ->when(function ($n) {
                 return $n > 42;
             })
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue(
                     $number > 42,
                     "\$number was filtered to be more than 42, but it's $number"
@@ -27,10 +27,10 @@ class WhenTest extends \PHPUnit_Framework_TestCase
             Generator\choose(0, 1000),
             Generator\choose(0, 1000)
         )
-            ->when(function($first, $second) {
+            ->when(function ($first, $second) {
                 return $first > 42 && $second > 23;
             })
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $this->assertTrue(
                     $first + $second > 42 + 23,
                     "\$first and \$second were filtered to be more than 42 and 23, but they are $first and $second"
@@ -44,7 +44,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
             Generator\choose(0, 1000)
         )
             ->when($this->greaterThan(42))
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue(
                     $number > 42,
                     "\$number was filtered to be more than 42, but it's $number"
@@ -59,7 +59,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
             Generator\choose(0, 1000)
         )
             ->when($this->greaterThan(42), $this->greaterThan(23))
-            ->then(function($first, $second) {
+            ->then(function ($first, $second) {
                 $this->assertTrue(
                     $first + $second > 42 + 23,
                     "\$first and \$second were filtered to be more than 42 and 23, but they are $first and $second"
@@ -74,7 +74,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
         )
             ->when($this->greaterThan(42))
             ->and($this->lessThan(900))
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue(
                     $number > 42 && $number < 900,
                     "\$number was filtered to be between 42 and 900, but it is $number"
@@ -88,7 +88,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
             Generator\choose(0, 1000)
         )
             ->when($this->greaterThan(800))
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue(
                     $number > 800
                 );
@@ -106,7 +106,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
             Generator\choose(0, 1000)
         )
             ->when($this->greaterThan(100))
-            ->then(function($number) {
+            ->then(function ($number) {
                 $this->assertTrue(
                     $number <= 100,
                     "\$number should be less or equal to 100, but it is $number"
@@ -119,10 +119,10 @@ class WhenTest extends \PHPUnit_Framework_TestCase
         $this->forAll(
             Generator\seq(Generator\elements(1, 2, 3))
         )
-            ->when(function($seq) {
+            ->when(function ($seq) {
                 return count($seq) > 0;
             })
-            ->then(function($seq) {
+            ->then(function ($seq) {
                 $this->assertGreaterThan(0, count($seq));
             });
     }

--- a/src/Eris/Antecedent/IndependentConstraintsAntecedent.php
+++ b/src/Eris/Antecedent/IndependentConstraintsAntecedent.php
@@ -30,5 +30,4 @@ class IndependentConstraintsAntecedent implements Antecedent
         }
         return true;
     }
-
 }

--- a/src/Eris/Antecedent/SingleCallbackAntecedent.php
+++ b/src/Eris/Antecedent/SingleCallbackAntecedent.php
@@ -22,4 +22,3 @@ class SingleCallbackAntecedent implements Antecedent
         return call_user_func_array($this->callback, $values);
     }
 }
-

--- a/src/Eris/Generator/AssociativeArrayGenerator.php
+++ b/src/Eris/Generator/AssociativeArrayGenerator.php
@@ -43,7 +43,7 @@ class AssociativeArrayGenerator implements Generator
     private function mapToAssociativeArray(GeneratedValue $tuple)
     {
         return $tuple->map(
-            function($value) {
+            function ($value) {
                 $associativeArray = [];
                 $keys = array_keys($this->generators);
                 for ($i = 0; $i < count($value); $i++) {

--- a/src/Eris/Generator/BindGenerator.php
+++ b/src/Eris/Generator/BindGenerator.php
@@ -35,7 +35,7 @@ class BindGenerator implements Generator
 
     public function shrink(GeneratedValue $element)
     {
-        list ($outerGeneratorValue, $innerGeneratorValue) = $element->input();
+        list($outerGeneratorValue, $innerGeneratorValue) = $element->input();
         // TODO: shrink also the second generator
         $outerGenerator = call_user_func($this->outerGeneratorFactory, $innerGeneratorValue->unbox());
         $shrinkedOuterGeneratorValue = $outerGenerator->shrink($outerGeneratorValue);
@@ -47,7 +47,7 @@ class BindGenerator implements Generator
 
     public function contains(GeneratedValue $element)
     {
-        list ($outerGeneratorValue, $innerGeneratorValue) = $element->input();
+        list($outerGeneratorValue, $innerGeneratorValue) = $element->input();
         $outerGenerator = call_user_func($this->outerGeneratorFactory, $innerGeneratorValue->unbox());
         return $outerGenerator->contains($outerGeneratorValue);
     }

--- a/src/Eris/Generator/ChooseGenerator.php
+++ b/src/Eris/Generator/ChooseGenerator.php
@@ -19,7 +19,8 @@ if (!defined('ERIS_PHP_INT_MIN')) {
  * @param $y int The other boundary of the range
  * @return Generator\ChooseGenerator
  */
-function choose($lowerLimit, $upperLimit) {
+function choose($lowerLimit, $upperLimit)
+{
     return new ChooseGenerator($lowerLimit, $upperLimit);
 }
 

--- a/src/Eris/Generator/ContainmentCheck.php
+++ b/src/Eris/Generator/ContainmentCheck.php
@@ -1,5 +1,6 @@
 <?php
 namespace Eris\Generator;
+
 use DomainException;
 
 class ContainmentCheck

--- a/src/Eris/Generator/DateGenerator.php
+++ b/src/Eris/Generator/DateGenerator.php
@@ -7,7 +7,7 @@ use DomainException;
 
 function date($lowerLimit = null, $upperLimit = null)
 {
-    $box = function($date) {
+    $box = function ($date) {
         if ($date === null) {
             return $date;
         }
@@ -16,7 +16,7 @@ function date($lowerLimit = null, $upperLimit = null)
         }
         return new DateTime($date);
     };
-    $withDefault = function($value, $default) {
+    $withDefault = function ($value, $default) {
         if ($value !== null) {
             return $value;
         }

--- a/src/Eris/Generator/FrequencyGenerator.php
+++ b/src/Eris/Generator/FrequencyGenerator.php
@@ -27,7 +27,7 @@ class FrequencyGenerator implements Generator
         }
         $this->generators = array_reduce(
             $generatorsWithFrequency,
-            function($generators, $generatorWithFrequency) {
+            function ($generators, $generatorWithFrequency) {
                 list($frequency, $generator) = $generatorWithFrequency;
                 $frequency = $this->ensureIsFrequency($generatorWithFrequency[0]);
                 $generator = ensureIsGenerator($generatorWithFrequency[1]);
@@ -45,7 +45,7 @@ class FrequencyGenerator implements Generator
 
     public function __invoke($size)
     {
-        list ($index, $generator) = $this->pickFrom($this->generators);
+        list($index, $generator) = $this->pickFrom($this->generators);
         $originalValue = $generator->__invoke($size);
         return GeneratedValue::fromValueAndInput(
             $originalValue->unbox(),
@@ -107,7 +107,7 @@ class FrequencyGenerator implements Generator
     private function frequenciesFrom($generators)
     {
         return array_map(
-            function($generatorWithFrequency) {
+            function ($generatorWithFrequency) {
                 return $generatorWithFrequency['frequency'];
             },
             $generators

--- a/src/Eris/Generator/GeneratedValue.php
+++ b/src/Eris/Generator/GeneratedValue.php
@@ -90,7 +90,7 @@ final class GeneratedValue
     public function derivedIn($generatorName)
     {
         return $this->map(
-            function($value) { return $value; },
+            function ($value) { return $value; },
             $generatorName
         );
     }

--- a/src/Eris/Generator/IntegerGenerator.php
+++ b/src/Eris/Generator/IntegerGenerator.php
@@ -18,7 +18,7 @@ function int()
  */
 function pos()
 {
-    $mustBeStrictlyPositive = function($n) {
+    $mustBeStrictlyPositive = function ($n) {
         return abs($n) + 1;
     };
     return new IntegerGenerator($mustBeStrictlyPositive);
@@ -26,7 +26,7 @@ function pos()
 
 function nat()
 {
-    $mustBeNatural = function($n) {
+    $mustBeNatural = function ($n) {
         return abs($n);
     };
     return new IntegerGenerator($mustBeNatural);
@@ -37,7 +37,7 @@ function nat()
  */
 function neg()
 {
-    $mustBeStrictlyNegative = function($n) {
+    $mustBeStrictlyNegative = function ($n) {
         return (-1) * (abs($n) + 1);
     };
     return new IntegerGenerator($mustBeStrictlyNegative);
@@ -107,7 +107,7 @@ class IntegerGenerator implements Generator
 
     private function identity()
     {
-        return function($n) {
+        return function ($n) {
             return $n;
         };
     }

--- a/src/Eris/Generator/NamesGenerator.php
+++ b/src/Eris/Generator/NamesGenerator.php
@@ -19,7 +19,7 @@ class NamesGenerator implements Generator
     {
         return new self(
             array_map(
-                function($line) {
+                function ($line) {
                     return trim($line, " \n");
                 },
                 file(__DIR__ . "/first_names.txt")
@@ -72,7 +72,7 @@ class NamesGenerator implements Generator
 
     private function lengthLessThanOrEqualTo($size)
     {
-        return function($name) use ($size) {
+        return function ($name) use ($size) {
             return strlen($name) <= $size;
         };
     }
@@ -80,7 +80,7 @@ class NamesGenerator implements Generator
     private function lengthSlightlyLessThan($size)
     {
         $lowerLength = $size - 1;
-        return function($name) use ($lowerLength) {
+        return function ($name) use ($lowerLength) {
             return strlen($name) === $lowerLength;
         };
     }
@@ -99,7 +99,7 @@ class NamesGenerator implements Generator
         $minimumDistance = min($distances);
         $candidatesWithEqualDistance = array_filter(
             $distances,
-            function($distance) use ($minimumDistance) {
+            function ($distance) use ($minimumDistance) {
                 return $distance == $minimumDistance;
             }
         );

--- a/src/Eris/Generator/OneOfGenerator.php
+++ b/src/Eris/Generator/OneOfGenerator.php
@@ -15,7 +15,8 @@ class OneOfGenerator implements Generator
 {
     private $generator;
 
-    public function __construct($generators) {
+    public function __construct($generators)
+    {
         $this->generator = new FrequencyGenerator($this->allWithSameFrequency($generators));
     }
 
@@ -37,7 +38,7 @@ class OneOfGenerator implements Generator
     private function allWithSameFrequency($generators)
     {
         return array_map(
-            function($generator) {
+            function ($generator) {
                 return [1, $generator];
             },
             $generators

--- a/src/Eris/Generator/RegexGenerator.php
+++ b/src/Eris/Generator/RegexGenerator.php
@@ -39,8 +39,8 @@ class RegexGenerator implements Generator
         $gen   = new SimpleRandom(rand());
         $result = null;
 
-        $parser = new Parser($lexer,new Scope(),new Scope());
-        $parser->parse()->getResult()->generate($result,$gen);
+        $parser = new Parser($lexer, new Scope(), new Scope());
+        $parser->parse()->getResult()->generate($result, $gen);
 
         return GeneratedValue::fromJustValue($result, 'regex');
     }

--- a/src/Eris/Generator/SequenceGenerator.php
+++ b/src/Eris/Generator/SequenceGenerator.php
@@ -63,7 +63,7 @@ class SequenceGenerator implements Generator
         $input = array_values($input);
         return GeneratedValue::fromValueAndInput(
             array_map(
-                function($element) { return $element->unbox(); },
+                function ($element) { return $element->unbox(); },
                 $input
             ),
             $input,

--- a/src/Eris/Generator/SetGenerator.php
+++ b/src/Eris/Generator/SetGenerator.php
@@ -63,7 +63,7 @@ class SetGenerator implements Generator
         unset($input[$indexOfElementToRemove]);
         $input = array_values($input);
         return GeneratedValue::fromValueAndInput(
-            array_map(function($element) {
+            array_map(function ($element) {
                 return $element->unbox();
             }, $input),
             array_values($input),

--- a/src/Eris/Generator/SubsetGenerator.php
+++ b/src/Eris/Generator/SubsetGenerator.php
@@ -35,7 +35,7 @@ class SubsetGenerator implements Generator
             $elementPresent = $binaryDescription{$i};
             if ($elementPresent == "1") {
                 $subset[] = $this->universe[$i];
-            } 
+            }
         }
 
         return GeneratedValue::fromJustValue($subset, 'subset');

--- a/src/Eris/Generator/SuchThatGenerator.php
+++ b/src/Eris/Generator/SuchThatGenerator.php
@@ -83,11 +83,11 @@ class SuchThatGenerator implements Generator
             } catch (PHPUnit_Framework_ExpectationFailedException $e) {
                 return false;
             }
-        } 
+        }
 
         if (is_callable($this->filter)) {
             return call_user_func($this->filter, $value->unbox());
-        } 
+        }
 
         throw new LogicException("Specified filter does not seem to be of the correct type. Please pass a callable or a PHPUnit_Framework_Constraint instead of " . var_export($this->filter, true));
     }

--- a/src/Eris/Generator/TupleGenerator.php
+++ b/src/Eris/Generator/TupleGenerator.php
@@ -37,14 +37,14 @@ class TupleGenerator implements Generator
     public function __invoke($size)
     {
         $input = array_map(
-            function($generator) use ($size) {
+            function ($generator) use ($size) {
                 return $generator($size);
             },
             $this->generators
         );
         return GeneratedValue::fromValueAndInput(
             array_map(
-                function($value) {
+                function ($value) {
                     return $value->unbox();
                 },
                 $input
@@ -81,10 +81,10 @@ class TupleGenerator implements Generator
         }
         return GeneratedValue::fromValueAndInput(
             array_map(
-                function($element) { return $element->unbox(); },
+                function ($element) { return $element->unbox(); },
                 $input
             ),
-            $input, 
+            $input,
             'tuple'
         );
     }
@@ -109,7 +109,7 @@ class TupleGenerator implements Generator
     private function ensureAreAllGenerators(array $generators)
     {
         return array_map(
-            function($generator) {
+            function ($generator) {
                 if ($generator instanceof Generator) {
                     return $generator;
                 }

--- a/src/Eris/Listener/CollectFrequencies.php
+++ b/src/Eris/Listener/CollectFrequencies.php
@@ -4,7 +4,7 @@ namespace Eris\Listener;
 use Eris\Listener;
 use InvalidArgumentException;
 
-function collectFrequencies(callable $collectFunction = null) 
+function collectFrequencies(callable $collectFunction = null)
 {
     return new CollectFrequencies($collectFunction);
 }
@@ -19,7 +19,7 @@ class CollectFrequencies
     public function __construct($collectFunction = null)
     {
         if ($collectFunction === null) {
-            $collectFunction = function(/*...*/) { 
+            $collectFunction = function (/*...*/) {
                 $generatedValues = func_get_args();
                 if (count($generatedValues) === 1) {
                     $value = $generatedValues[0];
@@ -28,7 +28,7 @@ class CollectFrequencies
                 }
 
                 if (is_string($value) || is_integer($value)) {
-                    return $value; 
+                    return $value;
                 } else {
                     return json_encode($value);
                 }
@@ -50,7 +50,7 @@ class CollectFrequencies
     public function newGeneration(array $generatedValues, $iteration)
     {
         $values = array_map(
-            function($generatedValue) {
+            function ($generatedValue) {
                 return $generatedValue->unbox();
             },
             $generatedValues

--- a/src/Eris/Quantifier/Evaluation.php
+++ b/src/Eris/Quantifier/Evaluation.php
@@ -21,8 +21,8 @@ final class Evaluation
     private function __construct($assertion)
     {
         $this->assertion = $assertion;
-        $this->onFailure = function() {};
-        $this->onSuccess = function() {};
+        $this->onFailure = function () {};
+        $this->onSuccess = function () {};
     }
 
     public function with(GeneratedValue $values)

--- a/src/Eris/Quantifier/ForAll.php
+++ b/src/Eris/Quantifier/ForAll.php
@@ -86,9 +86,9 @@ class ForAll
         $arguments = func_get_args();
         if ($arguments[0] instanceof Antecedent) {
             $antecedent = $arguments[0];
-        } else if ($arguments[0] instanceof PHPUnit_Framework_Constraint) {
+        } elseif ($arguments[0] instanceof PHPUnit_Framework_Constraint) {
             $antecedent = Antecedent\IndependentConstraintsAntecedent::fromAll($arguments);
-        } else if ($arguments && count($arguments) == 1) {
+        } elseif ($arguments && count($arguments) == 1) {
             $antecedent = Antecedent\SingleCallbackAntecedent::from($arguments[0]);
         } else {
             throw new \InvalidArgumentException("Invalid call to when(): " . var_export($arguments, true));
@@ -130,16 +130,16 @@ class ForAll
                     // TODO: coupling between here and the TupleGenerator used inside?
                     ->with(GeneratedValue::fromValueAndInput(
                         $values,
-                        $generatedValues, 
+                        $generatedValues,
                         'tuple'
                     ))
-                    ->onFailure(function($generatedValues, $exception) use ($assertion) {
+                    ->onFailure(function ($generatedValues, $exception) use ($assertion) {
                         if (!$this->shrinkingEnabled) {
                             throw $exception;
                         }
                         $shrinking = $this->shrinkerFactory->random($this->generators, $assertion);
                         // MAYBE: put into ShrinkerFactory?
-                        $shrinking->addGoodShrinkCondition(function(GeneratedValue $generatedValues) {
+                        $shrinking->addGoodShrinkCondition(function (GeneratedValue $generatedValues) {
                             return $this->antecedentsAreSatisfied($generatedValues->unbox());
                         });
                         $shrinking->from($generatedValues, $exception);
@@ -185,7 +185,7 @@ class ForAll
     private function generatorsFrom($supposedToBeGenerators)
     {
         $generators = [];
-        foreach($supposedToBeGenerators as $supposedToBeGenerator) {
+        foreach ($supposedToBeGenerators as $supposedToBeGenerator) {
             if (!$supposedToBeGenerator instanceof Generator) {
                 $generators[] = new Generator\ConstantGenerator($supposedToBeGenerator);
             } else {
@@ -223,7 +223,7 @@ class ForAll
      */
     private function linearGrowth()
     {
-        return function($n) {
+        return function ($n) {
             return $n;
         };
     }
@@ -240,7 +240,7 @@ class ForAll
      */
     private function triangleNumber()
     {
-        return function($n) {
+        return function ($n) {
             if ($n === 0) {
                 return 0;
             }

--- a/src/Eris/Quantifier/TimeBasedTerminationCondition.php
+++ b/src/Eris/Quantifier/TimeBasedTerminationCondition.php
@@ -6,7 +6,7 @@ use Eris\Listener\EmptyListener;
 use DateTime;
 use DateInterval;
 
-class TimeBasedTerminationCondition 
+class TimeBasedTerminationCondition
     extends EmptyListener
     implements TerminationCondition, Listener
 {

--- a/src/Eris/Shrinker/NoTimeLimit.php
+++ b/src/Eris/Shrinker/NoTimeLimit.php
@@ -5,7 +5,6 @@ class NoTimeLimit implements TimeLimit
 {
     public function start()
     {
-        
     }
 
     public function hasBeenReached()

--- a/src/Eris/Shrinker/Random.php
+++ b/src/Eris/Shrinker/Random.php
@@ -23,7 +23,7 @@ class Random // implements Shrinker
 
     public function setTimeLimit(TimeLimit $timeLimit)
     {
-        $this->timeLimit = $timeLimit; 
+        $this->timeLimit = $timeLimit;
     }
 
     public function addGoodShrinkCondition(callable $condition)
@@ -36,12 +36,12 @@ class Random // implements Shrinker
      */
     public function from(GeneratedValue $elements, AssertionFailed $exception)
     {
-        $onBadShrink = function() use (&$exception) {
+        $onBadShrink = function () use (&$exception) {
             $this->attempts->increase();
             $this->attempts->ensureLimit($exception);
         };
 
-        $onGoodShrink = function($elementsAfterShrink, $exceptionAfterShrink) use (&$elements, &$exception) {
+        $onGoodShrink = function ($elementsAfterShrink, $exceptionAfterShrink) use (&$elements, &$exception) {
             $this->attempts->reset();
             $elements = $elementsAfterShrink;
             $exception = $exceptionAfterShrink;

--- a/src/Eris/Shrinker/ShrinkerFactory.php
+++ b/src/Eris/Shrinker/ShrinkerFactory.php
@@ -17,7 +17,7 @@ class ShrinkerFactory
 
     public function random(array $generators, callable $assertion)
     {
-        $shrinker = new Random($generators, $assertion);    
+        $shrinker = new Random($generators, $assertion);
         if ($this->options['timeLimit'] !== null) {
             $shrinker->setTimeLimit(FixedTimeLimit::realTime($this->options['timeLimit']));
         }

--- a/src/Eris/TestTrait.php
+++ b/src/Eris/TestTrait.php
@@ -51,7 +51,7 @@ trait TestTrait
      */
     public static function loadAllErisGenerators()
     {
-        foreach(glob(__DIR__ . '/Generator/*.php') as $filename) {
+        foreach (glob(__DIR__ . '/Generator/*.php') as $filename) {
             require_once($filename);
         }
     }
@@ -61,7 +61,7 @@ trait TestTrait
      */
     public static function loadAllErisAntecedents()
     {
-        foreach(glob(__DIR__ . '/Antecedent/*.php') as $filename) {
+        foreach (glob(__DIR__ . '/Antecedent/*.php') as $filename) {
             require_once($filename);
         }
     }
@@ -71,7 +71,7 @@ trait TestTrait
      */
     public static function loadAllErisListeners()
     {
-        foreach(glob(__DIR__ . '/Listener/*.php') as $filename) {
+        foreach (glob(__DIR__ . '/Listener/*.php') as $filename) {
             require_once($filename);
         }
     }
@@ -110,7 +110,7 @@ trait TestTrait
             $terminationCondition = new Quantifier\TimeBasedTerminationCondition('time', $interval);
             $this->listeners[] = $terminationCondition;
             $this->terminationConditions[] = $terminationCondition;
-        } else if (is_integer($limit)) {
+        } elseif (is_integer($limit)) {
             $this->iterations = $limit;
         } else {
             throw new InvalidArgumentException("The limit " . var_export($limit, true) . " is not valid. Please pass an integer or DateInterval.");

--- a/test/Eris/ExampleEnd2EndTest.php
+++ b/test/Eris/ExampleEnd2EndTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Eris;
+
 use SimpleXMLElement;
 
 class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase

--- a/test/Eris/Generator/BindGeneratorTest.php
+++ b/test/Eris/Generator/BindGeneratorTest.php
@@ -13,7 +13,7 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new BindGenerator(
             // TODO: order of parameters should be consistent with map, or not?
             ConstantGenerator::box(4),
-            function($n) {
+            function ($n) {
                 return new ChooseGenerator($n, $n+10);
             }
         );
@@ -27,7 +27,7 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new BindGenerator(
             new ChooseGenerator(0, 5),
-            function($n) {
+            function ($n) {
                 return new ChooseGenerator($n, $n + 10);
             }
         );
@@ -48,20 +48,20 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
         $firstGenerator = new BindGenerator(
             new BindGenerator(
                 new ChooseGenerator(0, 5),
-                function($n) {
+                function ($n) {
                     return new ChooseGenerator($n * 10, $n * 10 + 1);
                 }
             ),
-            function($m) {
+            function ($m) {
                 return new VectorGenerator($m, new IntegerGenerator());
             }
         );
         $secondGenerator = new BindGenerator(
             new ChooseGenerator(0, 5),
-            function($n) {
+            function ($n) {
                 return new BindGenerator(
                     new ChooseGenerator($n * 10, $n * 10 + 1),
-                    function($m) {
+                    function ($m) {
                         return new VectorGenerator($m, new IntegerGenerator());
                     }
                 );

--- a/test/Eris/Generator/ChooseGeneratorTest.php
+++ b/test/Eris/Generator/ChooseGeneratorTest.php
@@ -51,7 +51,7 @@ class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertGreaterThan(
             40,
-            count(array_filter($values, function($n) { return $n->unbox() > 0; })),
+            count(array_filter($values, function ($n) { return $n->unbox() > 0; })),
             "The positive numbers should be a vast majority given the interval [-10, 10000]"
         );
     }

--- a/test/Eris/Generator/DateGeneratorTest.php
+++ b/test/Eris/Generator/DateGeneratorTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Eris\Generator;
+
 use DateTime;
 
 class DateGeneratorTest extends \PHPUnit_Framework_TestCase

--- a/test/Eris/Generator/FrequencyGeneratorTest.php
+++ b/test/Eris/Generator/FrequencyGeneratorTest.php
@@ -119,5 +119,4 @@ class FrequencyGeneratorTest extends \PHPUnit_Framework_TestCase
         }
         return $countOf;
     }
-
 }

--- a/test/Eris/Generator/GeneratedValueTest.php
+++ b/test/Eris/Generator/GeneratedValueTest.php
@@ -16,7 +16,7 @@ class GeneratedValueTest extends \PHPUnit_Framework_TestCase
                 'derived-generator'
             ),
             $initialValue->map(
-                function($value) {
+                function ($value) {
                     return $value * 2;
                 },
                 'derived-generator'

--- a/test/Eris/Generator/IntegerGeneratorTest.php
+++ b/test/Eris/Generator/IntegerGeneratorTest.php
@@ -41,7 +41,7 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertGreaterThan(
             400,
-            count(array_filter($values, function($n) { return $n->unbox() > 0; })),
+            count(array_filter($values, function ($n) { return $n->unbox() > 0; })),
             "The positive numbers should be a vast majority given the interval [-10, 10000]"
         );
     }

--- a/test/Eris/Generator/MapGeneratorTest.php
+++ b/test/Eris/Generator/MapGeneratorTest.php
@@ -11,7 +11,7 @@ class MapGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGeneratesAGeneratedValueObject()
     {
         $generator = new MapGenerator(
-            function($n) { return $n * 2; },
+            function ($n) { return $n * 2; },
             ConstantGenerator::box(1)
         );
         $this->assertEquals(
@@ -23,7 +23,7 @@ class MapGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testShrinksTheOriginalInput()
     {
         $generator = new MapGenerator(
-            function($n) { return $n * 2; },
+            function ($n) { return $n * 2; },
             new ChooseGenerator(1, 100)
         );
         $element = $generator->__invoke($this->size);
@@ -37,7 +37,7 @@ class MapGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testChecksTheContainmentOfTheOriginalInput()
     {
         $generator = new MapGenerator(
-            function($n) { return $n * 2; },
+            function ($n) { return $n * 2; },
             new ChooseGenerator(1, 100)
         );
         $element = $generator->__invoke($this->size);

--- a/test/Eris/Generator/RegexGeneratorTest.php
+++ b/test/Eris/Generator/RegexGeneratorTest.php
@@ -29,7 +29,7 @@ class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
         for ($i = 0; $i < 100; $i++) {
             $value = $generator($this->size)->unbox();
             $this->assertTrue(
-                $generator->contains(GeneratedValue::fromJustValue($value)), 
+                $generator->contains(GeneratedValue::fromJustValue($value)),
                 "Failed asserting that " . var_export($value, true) . " matches the regexp $expression"
             );
         }

--- a/test/Eris/Generator/SetGeneratorTest.php
+++ b/test/Eris/Generator/SetGeneratorTest.php
@@ -82,9 +82,8 @@ class SetGeneratorTest extends \PHPUnit_Framework_TestCase
         sort($generated);
         $this->assertTrue(
             array_unique($generated) === $generated,
-            "There are repeated elements inside a generated value: " 
+            "There are repeated elements inside a generated value: "
             . var_export($generated, true)
         );
     }
-
 }

--- a/test/Eris/Generator/SubsetGeneratorTest.php
+++ b/test/Eris/Generator/SubsetGeneratorTest.php
@@ -84,9 +84,8 @@ class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
         sort($generated);
         $this->assertTrue(
             array_unique($generated) === $generated,
-            "There are repeated elements inside a generated value: " 
+            "There are repeated elements inside a generated value: "
             . var_export($generated, true)
         );
     }
-
 }

--- a/test/Eris/Generator/SuchThatGeneratorTest.php
+++ b/test/Eris/Generator/SuchThatGeneratorTest.php
@@ -11,7 +11,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGeneratesAGeneratedValueObject()
     {
         $generator = new SuchThatGenerator(
-            function($n) { return $n % 2 == 0; },
+            function ($n) { return $n % 2 == 0; },
             ConstantGenerator::box(10)
         );
         $this->assertSame(
@@ -23,7 +23,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testAcceptsPHPUnitConstraints()
     {
         $generator = new SuchThatGenerator(
-            $this->callback(function($n) { return $n % 2 == 0; }),
+            $this->callback(function ($n) { return $n % 2 == 0; }),
             ConstantGenerator::box(10)
         );
         $this->assertSame(
@@ -35,7 +35,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testShrinksTheOriginalInput()
     {
         $generator = new SuchThatGenerator(
-            function($n) { return $n % 2 == 0; },
+            function ($n) { return $n % 2 == 0; },
             new ChooseGenerator(0, 100)
         );
         $element = $generator->__invoke($this->size);
@@ -58,7 +58,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGivesUpGenerationIfTheFilterIsNotSatisfiedTooManyTimes()
     {
         $generator = new SuchThatGenerator(
-            function($n) { return $n % 2 == 0; },
+            function ($n) { return $n % 2 == 0; },
             ConstantGenerator::box(11)
         );
         $generator->__invoke($this->size);
@@ -67,7 +67,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGivesUpShrinkingIfTheFilterIsNotSatisfiedTooManyTimes()
     {
         $generator = new SuchThatGenerator(
-            function($n) { return $n % 250 == 0; },
+            function ($n) { return $n % 250 == 0; },
             new ChooseGenerator(0, 1000)
         );
         $unshrinkable = GeneratedValue::fromJustValue(470);

--- a/test/Eris/Generator/VectorGeneratorTest.php
+++ b/test/Eris/Generator/VectorGeneratorTest.php
@@ -9,7 +9,7 @@ class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->size = 10;
         $this->elementGenerator = new ChooseGenerator(1, 10);
         $this->vectorGenerator = new VectorGenerator($this->vectorSize, $this->elementGenerator);
-        $this->sum = function($acc, $item) {
+        $this->sum = function ($acc, $item) {
             $acc = $acc + $item;
             return $acc;
         };

--- a/test/Eris/Listener/LogTest.php
+++ b/test/Eris/Listener/LogTest.php
@@ -6,10 +6,10 @@ class LogTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->file = '/tmp/eris-log-unit-test.log';
-        $this->time = function() {
+        $this->time = function () {
             return 1300000000;
         };
-        $this->log = new Log($this->file, $this->time,1234);
+        $this->log = new Log($this->file, $this->time, 1234);
     }
 
     public function tearDown()
@@ -29,7 +29,7 @@ class LogTest extends \PHPUnit_Framework_TestCase
     public function testCleansTheFile()
     {
         $this->log->newGeneration([], 42);
-        $this->log = new Log($this->file, $this->time,1234);
+        $this->log = new Log($this->file, $this->time, 1234);
 
         $this->assertEquals("", file_get_contents($this->file));
     }

--- a/test/Eris/Quantifier/TimeBasedTerminationConditionTest.php
+++ b/test/Eris/Quantifier/TimeBasedTerminationConditionTest.php
@@ -7,7 +7,7 @@ class TimeBasedTerminationConditionTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        $this->time = function() {
+        $this->time = function () {
             return $this->currentTime;
         };
         $this->currentTime = 1300000000;

--- a/test/Eris/Shrinker/FixedTimeLimitTest.php
+++ b/test/Eris/Shrinker/FixedTimeLimitTest.php
@@ -8,7 +8,7 @@ class FixedTimeLimitTest extends \PHPUnit_Framework_TestCase
         $this->time = 1000000000;
         $limit = new FixedTimeLimit(
             30,
-            function() {
+            function () {
                 return $this->time;
             }
         );


### PR DESCRIPTION
This PR

* [x] requires `fabpot/php-cs-fixer`
* [x] adds a simple configuration, using the PSR-2 level
* [x] runs `php-cs-fixer` on Travis, against PHP5.6 only
* [x] adds a composer script to simplify running `php-cs-fixer`
* [x] runs `composer run-script cs`

Somewhat related to #82.

:information_desk_person: For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/1.11.
