### PR TITLE
Escape backslashes in "Reproduce with:"

### DIFF
--- a/src/PHPUnitCommand.php
+++ b/src/PHPUnitCommand.php
@@ -1,0 +1,27 @@
+<?php
+namespace Eris;
+
+final class PHPUnitCommand
+{
+    private $seed;
+    private $name;
+
+    private function __construct($seed, $name)
+    {
+        $this->seed = $seed;
+        $this->name = $name;
+    }
+
+    public static function fromSeedAndName($seed, $name)
+    {
+        return new self(
+            $seed,
+            str_replace('\\', '\\\\', $name)
+        );
+    }
+
+    public function __toString()
+    {
+        return "ERIS_SEED={$this->seed} vendor/bin/phpunit --filter {$this->name}";
+    }
+}

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -66,7 +66,7 @@ trait TestTrait
     {
         if ($this->hasFailed()) {
             global $argv;
-            $command = "ERIS_SEED={$this->seed} vendor/bin/phpunit --filter {$this->toString()}";
+            $command = PHPUnitCommand::fromSeedAndName($this->seed, $this->toString());
             echo PHP_EOL;
             echo "Reproduce with:", PHP_EOL;
             echo $command, PHP_EOL;

--- a/test/PHPUnitCommandTest.php
+++ b/test/PHPUnitCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace Eris;
+
+class PHPUnitCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public static function commandExamples()
+    {
+        return [
+            [
+                'Foo::testBar',
+                'ERIS_SEED=42 vendor/bin/phpunit --filter Foo::testBar'
+            ],
+            [
+                'Foo\\Bar::testBaz',
+                'ERIS_SEED=42 vendor/bin/phpunit --filter Foo\\\\Bar::testBaz'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider commandExamples
+     */
+    public function testItCanComposeFrom($name, $fullString)
+    {
+        $command = PHPUnitCommand::fromSeedAndName(42, $name);
+
+        $this->assertEquals($fullString, $command->__toString());
+    }
+}


### PR DESCRIPTION
`--filter` with single backslashes doesn't work properly