### PR TITLE
Use single quote when filtering by name

### DIFF
--- a/src/PHPUnitCommand.php
+++ b/src/PHPUnitCommand.php
@@ -22,6 +22,6 @@ final class PHPUnitCommand
 
     public function __toString()
     {
-        return "ERIS_SEED={$this->seed} vendor/bin/phpunit --filter {$this->name}";
+        return "ERIS_SEED={$this->seed} vendor/bin/phpunit --filter '{$this->name}'";
     }
 }

--- a/test/PHPUnitCommandTest.php
+++ b/test/PHPUnitCommandTest.php
@@ -8,11 +8,11 @@ class PHPUnitCommandTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 'Foo::testBar',
-                'ERIS_SEED=42 vendor/bin/phpunit --filter Foo::testBar'
+                'ERIS_SEED=42 vendor/bin/phpunit --filter \'Foo::testBar\''
             ],
             [
                 'Foo\\Bar::testBaz',
-                'ERIS_SEED=42 vendor/bin/phpunit --filter Foo\\\\Bar::testBaz'
+                'ERIS_SEED=42 vendor/bin/phpunit --filter \'Foo\\\\Bar::testBaz\''
             ]
         ];
     }


### PR DESCRIPTION
This is a follow up of #85 since I noticed that using backslash is not enough