### PR TITLE
Closes #100: suchThat() should not get stuck on a small size

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ The project follows [semantic versioning](http://semver.org/). `BC` stands for a
 
 ## 0.NEXT
 
+* Fixed bug: `suchThat()` fails to generated good values when all those from generator size 0 are exclude (#100).
 * BC: dropped the deprecated `Shrinker\Random`.
 
 ## 0.9.0

--- a/examples/SuchThatTest.php
+++ b/examples/SuchThatTest.php
@@ -88,6 +88,23 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
             ->then($this->numberIsBiggerThan(100));
     }
 
+    public function testSuchThatAvoidingTheEmptyListDoesNotGetStuckOnASmallGeneratorSize()
+    {
+        $this
+            ->forAll(
+                Generator\suchThat(
+                    function (array $ints) {
+                        return count($ints) > 0;
+                    },
+                    Generator\seq(Generator\int())
+                )
+            )
+            ->then(function (array $ints) use (&$i) {
+                $this->assertGreaterThanOrEqual(1, count($ints));
+            })
+        ;
+    }
+
     public function allNumbersAreBiggerThan($lowerLimit)
     {
         return function ($vector) use ($lowerLimit) {

--- a/src/Generator/SkipValueException.php
+++ b/src/Generator/SkipValueException.php
@@ -5,5 +5,4 @@ use Exception;
 
 class SkipValueException extends Exception
 {
-    
 }

--- a/src/Generator/SkipValueException.php
+++ b/src/Generator/SkipValueException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Eris\Generator;
+
+use Exception;
+
+class SkipValueException extends Exception
+{
+    
+}

--- a/src/Generator/SuchThatGenerator.php
+++ b/src/Generator/SuchThatGenerator.php
@@ -49,7 +49,7 @@ class SuchThatGenerator implements Generator
         $attempts = 0;
         while (!$this->predicate($value)) {
             if ($attempts >= $this->maximumAttempts) {
-                throw new LogicException("Tried to satisfy predicate $attempts times, but could not generate a good value. You should try to improve your generator to make it more likely to output good values, or to use a less restrictive condition. Last generated value was: " . $value);
+                throw new SkipValueException("Tried to satisfy predicate $attempts times, but could not generate a good value. You should try to improve your generator to make it more likely to output good values, or to use a less restrictive condition. Last generated value was: " . $value);
             }
             $value = $this->generator->__invoke($size, $rand);
             $attempts++;

--- a/src/Quantifier/ForAll.php
+++ b/src/Quantifier/ForAll.php
@@ -4,6 +4,7 @@ namespace Eris\Quantifier;
 use Eris\Antecedent;
 use Eris\Generator;
 use Eris\Generator\GeneratedValueSingle;
+use Eris\Generator\SkipValueException;
 use BadMethodCallException;
 use PHPUnit_Framework_Constraint;
 use PHPUnit\Framework\Constraint\Constraint;
@@ -118,13 +119,17 @@ class ForAll
             ) {
                 $generatedValues = [];
                 $values = [];
-                foreach ($this->generators as $name => $generator) {
-                    $value = $generator($sizes->at($iteration), $this->rand);
-                    if (!($value instanceof GeneratedValueSingle)) {
-                        throw new RuntimeException("The value returned by a generator should be an instance of GeneratedValueSingle, but it is " . var_export($value, true));
+                try {
+                    foreach ($this->generators as $name => $generator) {
+                        $value = $generator($sizes->at($iteration), $this->rand);
+                        if (!($value instanceof GeneratedValueSingle)) {
+                            throw new RuntimeException("The value returned by a generator should be an instance of GeneratedValueSingle, but it is " . var_export($value, true));
+                        }
+                        $generatedValues[] = $value;
+                        $values[] = $value->unbox();
                     }
-                    $generatedValues[] = $value;
-                    $values[] = $value->unbox();
+                } catch (SkipValueException $e) {
+                    continue;
                 }
                 $generation = GeneratedValueSingle::fromValueAndInput(
                     $values,

--- a/test/Generator/SuchThatGeneratorTest.php
+++ b/test/Generator/SuchThatGeneratorTest.php
@@ -60,7 +60,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException Eris\Generator\SkipValueException
      */
     public function testGivesUpGenerationIfTheFilterIsNotSatisfiedTooManyTimes()
     {


### PR DESCRIPTION
If after `$this->maximumAttempts` attempts SuchThatGenerator cannot
produce a good value, it should throw a special exception recognized by
ForAll. ForAll will skip this iteration and go on with a larger size
rather than continuing to use `$size = 0` which may produce always the
same value (then discarded).