### PR TITLE
Add missing backflash

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ use Eris\Generator;
 
 class ReadmeTest extends \PHPUnit_Framework_TestCase
 {
-    use Eris\TestTrait;
+    use \Eris\TestTrait;
 
     public function testNaturalNumbersMagnitude()
     {


### PR DESCRIPTION
Strictly speaking it is not wrong, as the example does not reside in a namespace.
However normally tests do reside in a namespace, so copying the example will
result in an error unless this is modified in most cases.