### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@ In property-based testing, several properties that the System Under Test must re
 
 ## Installation
 
-You can install Eris through [Composer](https://getcomposer.org/) by adding:
+You can install Eris through [Composer](https://getcomposer.org/) by running the following command in your terminal:
 
-```json
-    "require": {
-        "giorgiosironi/eris": "dev-master"
-    }
 ```
-
-to your composer.json, and run `composer update`.
+composer require --dev giorgiosironi/eris
+```
 
 You can run some of Eris example tests with `vendor/bin/phpunit vendor/giorgiosironi/eris/examples`.
 


### PR DESCRIPTION
There's no need to edit the `composer.json` by hand and then run `update`. Just `require` it. Composer will automatically pick the best/latest version for you (I think `dev-master` should be used almost never).

Also, as this is a testing tool, it should be placed in composers `require-dev` section instead of `require`.