### PR TITLE
Allow installation with PHPUnit 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - php: 5.6 # PHPUnit 5.7
       env: WITH_CS=true
     - php: 7 # PHPUnit 6.x
-    - php: 7.1 # PHPUnit 6.x
+    - php: 7.1 # PHPUnit 7.x
     - php: hhvm
       env: SKIP_LINT_TEST_CASES=1
       sudo: required

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.5"
     },
     "require-dev": {
-        "phpunit/phpunit": ">4,<7",
+        "phpunit/phpunit": ">4,<8",
         "friendsofphp/php-cs-fixer": "^2.0",
         "icomefromthenet/reverse-regex": "v0.0.6.3"
     },


### PR DESCRIPTION
At the moment Eris is preventing me from using the latest PHPUnit version in my project.

Seems like it works just fine with the latest version though :)