### PR TITLE
Update example to output a single line on PHP 7.2

### DIFF
--- a/examples/generating_integers.php
+++ b/examples/generating_integers.php
@@ -7,5 +7,5 @@ $eris = new Eris\Facade();
 $eris
     ->forAll(Generator\int())
     ->then(function ($integer) {
-        var_dump($integer);
+        echo var_export($integer, true) . PHP_EOL;
     });


### PR DESCRIPTION
Somewhere in the development leading up to PHP 7.2, `var_dump()` started outputting the file and line number as part of it's output. This causes one of the end-to-end tests to fail as the example script it uses outputs twice as many lines as expected.

This fixes this by using `var_export()` and a little wrapping to output useful debug data if something goes wrong and sensible output otherwise.