### PR TITLE
added Annotation handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: WITH_CS=true
     - php: 7 # PHPUnit 6.x
     - php: 7.1 # PHPUnit 7.x
+    - php: 7.2 # PHPUnit 7.x
     - php: hhvm
       env: SKIP_LINT_TEST_CASES=1
       sudo: required

--- a/docs/limits.rst
+++ b/docs/limits.rst
@@ -6,10 +6,12 @@ Time and iterations
 
 By default Eris extracts a sample of 100 values for each ``forAll()`` call, and runs the ``then()`` callback over each of them.
 
-For tests which take very long to run, it is possible to limit the number of elements in the sample, or to specify a time limit the test should not exceed. For this purpose, the you can use the following annotations:
+For tests which take very long to run, it is possible to limit the number of elements in the sample, or to specify a time limit the test should not exceed. For this purpose, the you can use the following:
 
-* `@eris-repeat {number}` with an integer requesting a fixed number of iterations;
-* `@eris-duration {definition}` with a `DateInterval`_ compatible definition.
+* Annotation `@eris-repeat {number}` with an integer requesting a fixed number of iterations;
+* Annotation `@eris-duration {definition}` with a `DateInterval`_ compatible definition.
+* ``limitTo()``-method with an integer requesting a fixed number of iterations;
+* ``limitTo()``-method with a `DateInterval`_ object from the standard PHP library.
  
 .. literalinclude:: ../examples/LimitToTest.php
    :language: php

--- a/docs/limits.rst
+++ b/docs/limits.rst
@@ -6,10 +6,10 @@ Time and iterations
 
 By default Eris extracts a sample of 100 values for each ``forAll()`` call, and runs the ``then()`` callback over each of them.
 
-For tests which take very long to run, it is possible to either limit the number of elements in the sample, or to specify a time limit the test should not exceed. For this purpose, the ``limitTo()`` method accepts either:
+For tests which take very long to run, it is possible to limit the number of elements in the sample, or to specify a time limit the test should not exceed. For this purpose, the you can use the following annotations:
 
-* an integer requesting a fixed number of iterations;
-* a `DateInterval`_ object from the standard PHP library.
+* `@eris-repeat {number}` with an integer requesting a fixed number of iterations;
+* `@eris-duration {definition}` with a `DateInterval`_ compatible definition.
  
 .. literalinclude:: ../examples/LimitToTest.php
    :language: php

--- a/docs/listeners.rst
+++ b/docs/listeners.rst
@@ -97,7 +97,7 @@ It is not advised to rely on this format for parsing, being it only oriented to 
 Minimum Evaluations
 ---
 
-The ``@eris-ratio {ratio}`` annotation instantiates and wires in a Listener that checks that at least ``ratio``% of the total number of inputs being generated is actually evaluated. This Listener is only needed in case of an aggressive use of ``when()``.
+The ``@eris-ratio {ratio}`` annotation or  the``minimumEvaluations($ratio)`` API method instantiate and wire in a Listener that checks that at least ``ratio``% of the total number of inputs being generated is actually evaluated. This Listener is only needed in case of an aggressive use of ``when()``.
 
 Management of this Listener is provided through this method instead of explicitly adding a Listener object, as there is a default Listener instantiated with a threshold of 0.5 that has to be replaced in case a new minimum is chosen.
 

--- a/docs/listeners.rst
+++ b/docs/listeners.rst
@@ -97,7 +97,7 @@ It is not advised to rely on this format for parsing, being it only oriented to 
 Minimum Evaluations
 ---
 
-The ``minimumEvaluations($ratio)`` API method instantiates and wires in a Listener that checks that at least ``$ratio`` of the total number of inputs being generated is actually evaluated. This Listener is only needed in case of an aggressive use of ``when()``.
+The ``@eris-ratio {ratio}`` annotation instantiates and wires in a Listener that checks that at least ``ratio``% of the total number of inputs being generated is actually evaluated. This Listener is only needed in case of an aggressive use of ``when()``.
 
 Management of this Listener is provided through this method instead of explicitly adding a Listener object, as there is a default Listener instantiated with a threshold of 0.5 that has to be replaced in case a new minimum is chosen.
 

--- a/docs/shrinking.rst
+++ b/docs/shrinking.rst
@@ -105,7 +105,7 @@ The shrinking for this test will not run for more than 2 seconds (although the t
 
     1) ShrinkingTimeLimitTest::testLengthPreservation
     RuntimeException: Eris has reached the time limit for shrinking (2s elapsed of 2s), here it is presenting the simplest failure case.
-    If you can afford to spend more time to find a simpler failing input, increase it with the annotation '@eris-shrink {seconds}'.
+    If you can afford to spend more time to find a simpler failing input, increase it with the annotation '@eris-shrink {seconds}' or $this->shrinkingTimeLimit($seconds).
 
     /home/giorgio/code/eris/src/Eris/Shrinker/Random.php:71
     /home/giorgio/code/eris/src/Eris/Quantifier/ForAll.php:128

--- a/docs/shrinking.rst
+++ b/docs/shrinking.rst
@@ -105,7 +105,7 @@ The shrinking for this test will not run for more than 2 seconds (although the t
 
     1) ShrinkingTimeLimitTest::testLengthPreservation
     RuntimeException: Eris has reached the time limit for shrinking (2s elapsed of 2s), here it is presenting the simplest failure case.
-    If you can afford to spend more time to find a simpler failing input, increase it with $this->shrinkingTimeLimit($seconds).
+    If you can afford to spend more time to find a simpler failing input, increase it with the annotation '@eris-shrink {seconds}'.
 
     /home/giorgio/code/eris/src/Eris/Shrinker/Random.php:71
     /home/giorgio/code/eris/src/Eris/Quantifier/ForAll.php:128

--- a/examples/CharacterTest.php
+++ b/examples/CharacterTest.php
@@ -27,10 +27,25 @@ class CharacterTest extends PHPUnit_Framework_TestCase
             });
     }
 
+    public function testMultiplePrintableCharacters()
+    {
+        $this
+            ->minimumEvaluationRatio(0.1)
+            ->forAll(
+                Generator\char(['basic-latin']),
+                Generator\char(['basic-latin'])
+            )
+            ->when(Antecedent\printableCharacters())
+            ->then(function ($first, $second) {
+                $this->assertFalse(ord($first) < 32);
+                $this->assertFalse(ord($second) < 32);
+            });
+    }
+
     /**
      * @eris-ratio 10
      */
-    public function testMultiplePrintableCharacters()
+    public function testMultiplePrintableCharactersFromAnnotation()
     {
         $this
             ->forAll(

--- a/examples/CharacterTest.php
+++ b/examples/CharacterTest.php
@@ -27,10 +27,12 @@ class CharacterTest extends PHPUnit_Framework_TestCase
             });
     }
 
+    /**
+     * @eris-ratio 10
+     */
     public function testMultiplePrintableCharacters()
     {
         $this
-            ->minimumEvaluationRatio(0.1)
             ->forAll(
                 Generator\char(['basic-latin']),
                 Generator\char(['basic-latin'])

--- a/examples/LimitToTest.php
+++ b/examples/LimitToTest.php
@@ -35,11 +35,25 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     }
      */
 
+    public function testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnored()
+    {
+        $this
+            ->minimumEvaluationRatio(0)
+            ->limitTo(new DateInterval('PT2S'))
+            ->forAll(
+                Generator\int()
+            )
+            ->then(function ($value) {
+                usleep(100 * 1000);
+                $this->assertTrue(true);
+            });
+    }
+
     /**
      * @eris-ratio 0
      * @eris-duration PT2S
      */
-    public function testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnored()
+    public function testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnoredFromAnnotation()
     {
         $this->forAll(
                 Generator\int()

--- a/examples/LimitToTest.php
+++ b/examples/LimitToTest.php
@@ -6,10 +6,12 @@ class LimitToTest extends PHPUnit_Framework_TestCase
 {
     use TestTrait;
 
+    /**
+     * @eris-repeat 5
+     */
     public function testNumberOfIterationsCanBeConfigured()
     {
-        $this->limitTo(5)
-             ->forAll(
+        $this->forAll(
                 Generator\int()
             )
             ->then(function ($value) {
@@ -33,11 +35,13 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     }
      */
 
+    /**
+     * @eris-ratio 0
+     * @eris-duration PT2S
+     */
     public function testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnored()
     {
-        $this->minimumEvaluationRatio(0.0)
-             ->limitTo(new DateInterval("PT2S"))
-             ->forAll(
+        $this->forAll(
                 Generator\int()
             )
             ->then(function ($value) {

--- a/examples/LogFileTest.php
+++ b/examples/LogFileTest.php
@@ -13,7 +13,7 @@ class LogFileTest extends PHPUnit_Framework_TestCase
             ->forAll(
                 Generator\int()
             )
-            ->hook(Listener\log('/tmp/eris-log-file-test.log'))
+            ->hook(Listener\log(sys_get_temp_dir().'/eris-log-file-test.log'))
             ->then(function ($number) {
                 $this->assertInternalType('integer', $number);
             });
@@ -25,7 +25,7 @@ class LogFileTest extends PHPUnit_Framework_TestCase
             ->forAll(
                 Generator\int()
             )
-            ->hook(Listener\log('/tmp/eris-log-file-shrinking.log'))
+            ->hook(Listener\log(sys_get_temp_dir().'/eris-log-file-shrinking.log'))
             ->then(function ($number) {
                 $this->assertLessThanOrEqual(42, $number);
             });

--- a/examples/MinimumEvaluationsTest.php
+++ b/examples/MinimumEvaluationsTest.php
@@ -19,10 +19,12 @@ class MinimumEvaluationsTest extends PHPUnit_Framework_TestCase
             });
     }
 
+    /**
+     * @eris-ratio 1
+     */
     public function testPassesBecauseOfTheArtificiallyLowMinimumEvaluationRatio()
     {
         $this
-            ->minimumEvaluationRatio(0.01)
             ->forAll(
                 Generator\choose(0, 100)
             )

--- a/examples/MinimumEvaluationsTest.php
+++ b/examples/MinimumEvaluationsTest.php
@@ -19,10 +19,25 @@ class MinimumEvaluationsTest extends PHPUnit_Framework_TestCase
             });
     }
 
+    public function testPassesBecauseOfTheArtificiallyLowMinimumEvaluationRatio()
+    {
+        $this
+            ->minimumEvaluationRatio(0.01)
+            ->forAll(
+                Generator\choose(0, 100)
+            )
+            ->when(function ($n) {
+                return $n > 90;
+            })
+            ->then(function ($number) {
+                $this->assertTrue($number * 2 > 90 * 2);
+            });
+    }
+
     /**
      * @eris-ratio 1
      */
-    public function testPassesBecauseOfTheArtificiallyLowMinimumEvaluationRatio()
+    public function testPassesBecauseOfTheArtificiallyLowMinimumEvaluationRatioFromAnnotation()
     {
         $this
             ->forAll(

--- a/examples/RandConfigurationTest.php
+++ b/examples/RandConfigurationTest.php
@@ -10,7 +10,7 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
     public function testUsingTheDefaultRandFunction()
     {
         $this
-            ->withRand('mt_rand')
+            ->withRand('rand')
             ->forAll(
                 Generator\int()
             )

--- a/examples/RandConfigurationTest.php
+++ b/examples/RandConfigurationTest.php
@@ -7,10 +7,21 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
 {
     use TestTrait;
 
+    public function testUsingTheDefaultRandFunction()
+    {
+        $this
+            ->withRand('mt_rand')
+            ->forAll(
+                Generator\int()
+            )
+            ->withMaxSize(1000 * 1000* 1000)
+            ->then($this->isInteger());
+    }
+
     /**
      * @eris-method rand
      */
-    public function testUsingTheDefaultRandFunction()
+    public function testUsingTheDefaultRandFunctionFromAnnotation()
     {
         $this
             ->forAll(
@@ -20,10 +31,21 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
             ->then($this->isInteger());
     }
 
+    public function testUsingTheDefaultMtRandFunction()
+    {
+        $this
+            ->withRand('mt_rand')
+            ->forAll(
+                Generator\int()
+            )
+            ->then($this->isInteger());
+    }
+
+
     /**
      * @eris-method mt_rand
      */
-    public function testUsingTheDefaultMtRandFunction()
+    public function testUsingTheDefaultMtRandFunctionFromAnnotation()
     {
         $this
             ->forAll(

--- a/examples/RandConfigurationTest.php
+++ b/examples/RandConfigurationTest.php
@@ -7,10 +7,12 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
 {
     use TestTrait;
 
+    /**
+     * @eris-method rand
+     */
     public function testUsingTheDefaultRandFunction()
     {
         $this
-            ->withRand('rand')
             ->forAll(
                 Generator\int()
             )
@@ -18,10 +20,12 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
             ->then($this->isInteger());
     }
 
+    /**
+     * @eris-method mt_rand
+     */
     public function testUsingTheDefaultMtRandFunction()
     {
         $this
-            ->withRand('mt_rand')
             ->forAll(
                 Generator\int()
             )

--- a/examples/SequenceTest.php
+++ b/examples/SequenceTest.php
@@ -1,6 +1,5 @@
 <?php
 use Eris\Generator;
-use Eris\Listener;
 
 class SequenceTest extends PHPUnit_Framework_TestCase
 {

--- a/examples/ShrinkingTimeLimitTest.php
+++ b/examples/ShrinkingTimeLimitTest.php
@@ -14,10 +14,28 @@ class ShrinkingTimeLimitTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
+    public function testLengthPreservation()
+    {
+        $this
+            ->shrinkingTimeLimit(2)
+            ->forAll(
+                Generator\string(),
+                Generator\string()
+            )
+            ->then(function ($first, $second) {
+                $result = very_slow_concatenation($first, $second);
+                $this->assertEquals(
+                    strlen($first) + strlen($second),
+                    strlen($result),
+                    "Concatenating '$first' to '$second' gives '$result'" . PHP_EOL
+                );
+            });
+    }
+
     /**
      * @eris-shrink 2
      */
-    public function testLengthPreservation()
+    public function testLengthPreservationFromAnnotation()
     {
         $this
             ->forAll(

--- a/examples/ShrinkingTimeLimitTest.php
+++ b/examples/ShrinkingTimeLimitTest.php
@@ -14,10 +14,12 @@ class ShrinkingTimeLimitTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
+    /**
+     * @eris-shrink 2
+     */
     public function testLengthPreservation()
     {
         $this
-            ->shrinkingTimeLimit(2)
             ->forAll(
                 Generator\string(),
                 Generator\string()

--- a/examples/StringTest.php
+++ b/examples/StringTest.php
@@ -36,7 +36,7 @@ class StringTest extends PHPUnit_Framework_TestCase
                 Generator\string(),
                 Generator\string()
             )
-            ->hook(Listener\log('/tmp/eris-string-shrinking.log'))
+            ->hook(Listener\log(sys_get_temp_dir().'/eris-string-shrinking.log'))
             ->then(function ($first, $second) {
                 $result = string_concatenation($first, $second);
                 $this->assertEquals(

--- a/examples/SuchThatTest.php
+++ b/examples/SuchThatTest.php
@@ -55,7 +55,7 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
                     )
                 )
             )
-            ->hook(Listener\log('/tmp/eris-such-that.log'))
+            ->hook(Listener\log(sys_get_temp_dir().'/eris-such-that.log'))
             ->then($this->allNumbersAreBiggerThan(42));
     }
 

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -10,4 +10,13 @@ class Facade
         $this->erisSetupBeforeClass();
         $this->erisSetup();
     }
+
+    /**
+     * sadly this facade has no option to retrieve annotations of testcases
+     * @return array
+     */
+    protected function getAnnotations()
+    {
+        return array();
+    }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -10,10 +10,10 @@ interface Generator
 {
     /**
      * @param int The generation size
-     * @param callable  a rand() function
+     * @param Random\RandomRange
      * @return GeneratedValueSingle<T>
      */
-    public function __invoke($size, $rand);
+    public function __invoke($size, Random\RandomRange $rand);
 
     /**
      * The conditions for terminating are either:

--- a/src/Generator/AssociativeArrayGenerator.php
+++ b/src/Generator/AssociativeArrayGenerator.php
@@ -22,7 +22,7 @@ class AssociativeArrayGenerator implements Generator
         $this->tupleGenerator = new TupleGenerator(array_values($generators));
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         $tuple = $this->tupleGenerator->__invoke($size, $rand);
         return $this->mapToAssociativeArray($tuple);

--- a/src/Generator/AssociativeArrayGenerator.php
+++ b/src/Generator/AssociativeArrayGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 /**
  * @return AssociativeArrayGenerator
@@ -22,7 +23,7 @@ class AssociativeArrayGenerator implements Generator
         $this->tupleGenerator = new TupleGenerator(array_values($generators));
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $tuple = $this->tupleGenerator->__invoke($size, $rand);
         return $this->mapToAssociativeArray($tuple);

--- a/src/Generator/BindGenerator.php
+++ b/src/Generator/BindGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 function bind(Generator $innerGenerator, callable $outerGeneratorFactory)
 {
@@ -22,7 +23,7 @@ class BindGenerator implements Generator
         $this->outerGeneratorFactory = $outerGeneratorFactory;
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $innerGeneratorValue = $this->innerGenerator->__invoke($size, $rand);
         $outerGenerator = call_user_func($this->outerGeneratorFactory, $innerGeneratorValue->unbox());

--- a/src/Generator/BindGenerator.php
+++ b/src/Generator/BindGenerator.php
@@ -22,7 +22,7 @@ class BindGenerator implements Generator
         $this->outerGeneratorFactory = $outerGeneratorFactory;
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         $innerGeneratorValue = $this->innerGenerator->__invoke($size, $rand);
         $outerGenerator = call_user_func($this->outerGeneratorFactory, $innerGeneratorValue->unbox());

--- a/src/Generator/BooleanGenerator.php
+++ b/src/Generator/BooleanGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 function bool()
 {
@@ -11,10 +10,10 @@ function bool()
 
 class BooleanGenerator implements Generator
 {
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
         $booleanValues = [true, false];
-        $randomIndex = $rand(0, count($booleanValues) - 1);
+        $randomIndex = $rand->rand(0, count($booleanValues) - 1);
 
         return GeneratedValueSingle::fromJustValue($booleanValues[$randomIndex], 'boolean');
     }

--- a/src/Generator/BooleanGenerator.php
+++ b/src/Generator/BooleanGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 function bool()
 {
@@ -10,7 +11,7 @@ function bool()
 
 class BooleanGenerator implements Generator
 {
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         $booleanValues = [true, false];
         $randomIndex = $rand->rand(0, count($booleanValues) - 1);

--- a/src/Generator/CharacterGenerator.php
+++ b/src/Generator/CharacterGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 /**
  * Generates character in the ASCII 0-127 range.
@@ -49,7 +50,7 @@ class CharacterGenerator implements Generator
         $this->shrinkingProgression = ArithmeticProgression::discrete($this->lowerLimit);
     }
 
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         return GeneratedValueSingle::fromJustValue(chr($rand->rand($this->lowerLimit, $this->upperLimit)), 'character');
     }

--- a/src/Generator/CharacterGenerator.php
+++ b/src/Generator/CharacterGenerator.php
@@ -49,14 +49,13 @@ class CharacterGenerator implements Generator
         $this->shrinkingProgression = ArithmeticProgression::discrete($this->lowerLimit);
     }
 
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
-        return GeneratedValueSingle::fromJustValue(chr($rand($this->lowerLimit, $this->upperLimit)), 'character');
+        return GeneratedValueSingle::fromJustValue(chr($rand->rand($this->lowerLimit, $this->upperLimit)), 'character');
     }
 
     public function shrink(GeneratedValueSingle $element)
     {
-        $codePoint = ord($element->unbox());
         $shrinkedValue = chr($this->shrinkingProgression->next(ord($element->unbox())));
         return GeneratedValueSingle::fromJustValue($shrinkedValue, 'character');
     }

--- a/src/Generator/ChooseGenerator.php
+++ b/src/Generator/ChooseGenerator.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 use InvalidArgumentException;
+use Eris\Random\RandomRange;
 
 if (!defined('ERIS_PHP_INT_MIN')) {
     define('ERIS_PHP_INT_MIN', ~PHP_INT_MAX);
@@ -41,7 +42,7 @@ class ChooseGenerator implements Generator
         );
     }
 
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         $value = $rand->rand($this->lowerLimit, $this->upperLimit);
 

--- a/src/Generator/ChooseGenerator.php
+++ b/src/Generator/ChooseGenerator.php
@@ -3,7 +3,6 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 use InvalidArgumentException;
-use DomainException;
 
 if (!defined('ERIS_PHP_INT_MIN')) {
     define('ERIS_PHP_INT_MIN', ~PHP_INT_MAX);
@@ -42,9 +41,9 @@ class ChooseGenerator implements Generator
         );
     }
 
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
-        $value = $rand($this->lowerLimit, $this->upperLimit);
+        $value = $rand->rand($this->lowerLimit, $this->upperLimit);
 
         return GeneratedValueSingle::fromJustValue($value, 'choose');
     }

--- a/src/Generator/ConstantGenerator.php
+++ b/src/Generator/ConstantGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 /**
  * @param mixed $value  the only value to generate
@@ -27,7 +26,7 @@ class ConstantGenerator implements Generator
         $this->value = $value;
     }
 
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
         return GeneratedValueSingle::fromJustValue($this->value, 'constant');
     }

--- a/src/Generator/ConstantGenerator.php
+++ b/src/Generator/ConstantGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 /**
  * @param mixed $value  the only value to generate
@@ -26,7 +27,7 @@ class ConstantGenerator implements Generator
         $this->value = $value;
     }
 
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         return GeneratedValueSingle::fromJustValue($this->value, 'constant');
     }

--- a/src/Generator/DateGenerator.php
+++ b/src/Generator/DateGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 use DateTime;
 
 function date($lowerLimit = null, $upperLimit = null)
@@ -41,7 +42,7 @@ class DateGenerator implements Generator
         $this->intervalInSeconds = $upperLimit->getTimestamp() - $lowerLimit->getTimestamp();
     }
 
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         $generatedOffset = $rand->rand(0, $this->intervalInSeconds);
         return GeneratedValueSingle::fromJustValue(

--- a/src/Generator/DateGenerator.php
+++ b/src/Generator/DateGenerator.php
@@ -3,7 +3,6 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 use DateTime;
-use DomainException;
 
 function date($lowerLimit = null, $upperLimit = null)
 {
@@ -42,9 +41,9 @@ class DateGenerator implements Generator
         $this->intervalInSeconds = $upperLimit->getTimestamp() - $lowerLimit->getTimestamp();
     }
 
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
-        $generatedOffset = $rand(0, $this->intervalInSeconds);
+        $generatedOffset = $rand->rand(0, $this->intervalInSeconds);
         return GeneratedValueSingle::fromJustValue(
             $this->fromOffset($generatedOffset),
             'date'

--- a/src/Generator/ElementsGenerator.php
+++ b/src/Generator/ElementsGenerator.php
@@ -2,7 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
+use Eris\Random\RandomRange;
 
 function elements(/*$a, $b, ...*/)
 {
@@ -29,7 +29,7 @@ class ElementsGenerator implements Generator
         $this->domain = $domain;
     }
 
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         $index = $rand->rand(0, count($this->domain) - 1);
         return GeneratedValueSingle::fromJustValue($this->domain[$index], 'elements');

--- a/src/Generator/ElementsGenerator.php
+++ b/src/Generator/ElementsGenerator.php
@@ -29,9 +29,9 @@ class ElementsGenerator implements Generator
         $this->domain = $domain;
     }
 
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
-        $index = $rand(0, count($this->domain) - 1);
+        $index = $rand->rand(0, count($this->domain) - 1);
         return GeneratedValueSingle::fromJustValue($this->domain[$index], 'elements');
     }
 

--- a/src/Generator/FloatGenerator.php
+++ b/src/Generator/FloatGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 function float()
 {
@@ -14,7 +15,7 @@ class FloatGenerator implements Generator
     {
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $denominator = $rand->rand(1, $size) ?: 1;
 

--- a/src/Generator/FloatGenerator.php
+++ b/src/Generator/FloatGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 function float()
 {
@@ -15,13 +14,13 @@ class FloatGenerator implements Generator
     {
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
-        $denominator = $rand(1, $size) ?: 1;
+        $denominator = $rand->rand(1, $size) ?: 1;
 
-        $value = (float) $rand(0, $size) / (float) $denominator;
+        $value = (float) $rand->rand(0, $size) / (float) $denominator;
 
-        $signedValue = $rand(0, 1) === 0
+        $signedValue = $rand->rand(0, 1) === 0
             ? $value
             : $value * (-1);
         return GeneratedValueSingle::fromJustValue($signedValue, 'float');

--- a/src/Generator/FrequencyGenerator.php
+++ b/src/Generator/FrequencyGenerator.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 use InvalidArgumentException;
+use Eris\Random\RandomRange;
 
 /**
  * @return FrequencyGenerator
@@ -41,7 +42,7 @@ class FrequencyGenerator implements Generator
         );
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         list($index, $generator) = $this->pickFrom($this->generators, $rand);
         $originalValue = $generator->__invoke($size, $rand);
@@ -75,7 +76,7 @@ class FrequencyGenerator implements Generator
     /**
      * @return array  two elements: index and Generator object
      */
-    private function pickFrom($generators, \Eris\Random\RandomRange $rand)
+    private function pickFrom($generators, RandomRange $rand)
     {
         $acc = 0;
         $frequencies = $this->frequenciesFrom($generators);

--- a/src/Generator/FrequencyGenerator.php
+++ b/src/Generator/FrequencyGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 use InvalidArgumentException;
 
 /**
@@ -16,7 +15,6 @@ function frequency(/*$frequencyAndGenerator, $frequencyAndGenerator, ...*/)
 class FrequencyGenerator implements Generator
 {
     private $generators;
-    private $frequencies;
 
     public function __construct(array $generatorsWithFrequency)
     {
@@ -43,7 +41,7 @@ class FrequencyGenerator implements Generator
         );
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         list($index, $generator) = $this->pickFrom($this->generators, $rand);
         $originalValue = $generator->__invoke($size, $rand);
@@ -77,11 +75,11 @@ class FrequencyGenerator implements Generator
     /**
      * @return array  two elements: index and Generator object
      */
-    private function pickFrom($generators, $rand)
+    private function pickFrom($generators, \Eris\Random\RandomRange $rand)
     {
         $acc = 0;
         $frequencies = $this->frequenciesFrom($generators);
-        $random = $rand(1, array_sum($frequencies));
+        $random = $rand->rand(1, array_sum($frequencies));
         foreach ($generators as $index => $generator) {
             $acc += $generator['frequency'];
             if ($random <= $acc) {

--- a/src/Generator/GeneratedValueOptions.php
+++ b/src/Generator/GeneratedValueOptions.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use ArrayIterator;
-use IteratorAggregate;
 use LogicException;
 
 /**
@@ -31,9 +30,8 @@ class GeneratedValueOptions implements GeneratedValue
     {
         if ($value instanceof GeneratedValueOptions) {
             return $value->last();
-        } else {
-            return $value;
         }
+        return $value;
     }
 
     public function first()
@@ -62,13 +60,6 @@ class GeneratedValueOptions implements GeneratedValue
     public function derivedIn($generatorName)
     {
         throw new RuntimeException("GeneratedValueOptions::derivedIn() is needed, uncomment it");
-        /*
-         * Not sure this is needed.
-            return $this->map(
-                function ($value) { return $value; },
-                $generatorName
-            );
-         */
     }
 
     /**

--- a/src/Generator/IntegerGenerator.php
+++ b/src/Generator/IntegerGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 /**
  * Generates a positive or negative integer (with absolute value bounded by
@@ -60,7 +61,7 @@ class IntegerGenerator implements Generator
         }
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $value = $rand->rand(0, $size);
         $mapFn = $this->mapFn;

--- a/src/Generator/IntegerGenerator.php
+++ b/src/Generator/IntegerGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 /**
  * Generates a positive or negative integer (with absolute value bounded by
@@ -61,12 +60,12 @@ class IntegerGenerator implements Generator
         }
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
-        $value = $rand(0, $size);
+        $value = $rand->rand(0, $size);
         $mapFn = $this->mapFn;
 
-        $result = $rand(0, 1) === 0
+        $result = $rand->rand(0, 1) === 0
                           ? $mapFn($value)
                           : $mapFn($value * (-1));
         return GeneratedValueSingle::fromJustValue(

--- a/src/Generator/MapGenerator.php
+++ b/src/Generator/MapGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 // TODO: support calls like ($function . $generator)
 function map(callable $function, Generator $generator)
@@ -20,7 +21,7 @@ class MapGenerator implements Generator
         $this->generator = $generator;
     }
 
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         $input = $this->generator->__invoke($_size, $rand);
         return $input->map(

--- a/src/Generator/MapGenerator.php
+++ b/src/Generator/MapGenerator.php
@@ -20,7 +20,7 @@ class MapGenerator implements Generator
         $this->generator = $generator;
     }
 
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
         $input = $this->generator->__invoke($_size, $rand);
         return $input->map(

--- a/src/Generator/NamesGenerator.php
+++ b/src/Generator/NamesGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 function names()
 {
@@ -32,7 +33,7 @@ class NamesGenerator implements Generator
         $this->list = $list;
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $candidateNames = $this->filterDataSet(
             $this->lengthLessThanOrEqualTo($size)

--- a/src/Generator/NamesGenerator.php
+++ b/src/Generator/NamesGenerator.php
@@ -32,7 +32,7 @@ class NamesGenerator implements Generator
         $this->list = $list;
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         $candidateNames = $this->filterDataSet(
             $this->lengthLessThanOrEqualTo($size)
@@ -40,7 +40,7 @@ class NamesGenerator implements Generator
         if (!$candidateNames) {
             return GeneratedValueSingle::fromJustValue('', 'names');
         }
-        $index = $rand(0, count($candidateNames) - 1);
+        $index = $rand->rand(0, count($candidateNames) - 1);
         return GeneratedValueSingle::fromJustValue($candidateNames[$index], 'names');
     }
 

--- a/src/Generator/OneOfGenerator.php
+++ b/src/Generator/OneOfGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 /**
  * @return OneOfGenerator
@@ -20,7 +21,7 @@ class OneOfGenerator implements Generator
         $this->generator = new FrequencyGenerator($this->allWithSameFrequency($generators));
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         return $this->generator->__invoke($size, $rand);
     }

--- a/src/Generator/OneOfGenerator.php
+++ b/src/Generator/OneOfGenerator.php
@@ -20,7 +20,7 @@ class OneOfGenerator implements Generator
         $this->generator = new FrequencyGenerator($this->allWithSameFrequency($generators));
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         return $this->generator->__invoke($size, $rand);
     }

--- a/src/Generator/RegexGenerator.php
+++ b/src/Generator/RegexGenerator.php
@@ -33,10 +33,10 @@ class RegexGenerator implements Generator
         $this->expression = $expression;
     }
 
-    public function __invoke($_size, $rand)
+    public function __invoke($_size, \Eris\Random\RandomRange $rand)
     {
         $lexer = new Lexer($this->expression);
-        $gen   = new SimpleRandom($rand());
+        $gen   = new SimpleRandom($rand->rand());
         $result = null;
 
         $parser = new Parser($lexer, new Scope(), new Scope());

--- a/src/Generator/RegexGenerator.php
+++ b/src/Generator/RegexGenerator.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use BadFunctionCallException;
 use Eris\Generator;
+use Eris\Random\RandomRange;
 use ReverseRegex\Lexer;
 use ReverseRegex\Random\SimpleRandom;
 use ReverseRegex\Parser;
@@ -33,7 +34,7 @@ class RegexGenerator implements Generator
         $this->expression = $expression;
     }
 
-    public function __invoke($_size, \Eris\Random\RandomRange $rand)
+    public function __invoke($_size, RandomRange $rand)
     {
         $lexer = new Lexer($this->expression);
         $gen   = new SimpleRandom($rand->rand());

--- a/src/Generator/SequenceGenerator.php
+++ b/src/Generator/SequenceGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 function seq(Generator $singleElementGenerator)
 {
@@ -21,7 +22,7 @@ class SequenceGenerator implements Generator
         $this->singleElementGenerator = $singleElementGenerator;
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $sequenceLength = $rand->rand(0, $size);
         return $this->vector($sequenceLength)->__invoke($size, $rand);

--- a/src/Generator/SequenceGenerator.php
+++ b/src/Generator/SequenceGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 function seq(Generator $singleElementGenerator)
 {
@@ -22,9 +21,9 @@ class SequenceGenerator implements Generator
         $this->singleElementGenerator = $singleElementGenerator;
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
-        $sequenceLength = $rand(0, $size);
+        $sequenceLength = $rand->rand(0, $size);
         return $this->vector($sequenceLength)->__invoke($size, $rand);
     }
 

--- a/src/Generator/SetGenerator.php
+++ b/src/Generator/SetGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 /**
  * @param Generator $singleElementGenerator
@@ -22,7 +21,7 @@ class SetGenerator implements Generator
         $this->singleElementGenerator = $singleElementGenerator;
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         $setSize = rand(0, $size);
         $set = [];

--- a/src/Generator/SetGenerator.php
+++ b/src/Generator/SetGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 /**
  * @param Generator $singleElementGenerator
@@ -21,7 +22,7 @@ class SetGenerator implements Generator
         $this->singleElementGenerator = $singleElementGenerator;
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $setSize = rand(0, $size);
         $set = [];

--- a/src/Generator/StringGenerator.php
+++ b/src/Generator/StringGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 function string()
 {
@@ -10,7 +11,7 @@ function string()
 
 class StringGenerator implements Generator
 {
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $length = $rand->rand(0, $size);
 

--- a/src/Generator/StringGenerator.php
+++ b/src/Generator/StringGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 function string()
 {
@@ -11,13 +10,13 @@ function string()
 
 class StringGenerator implements Generator
 {
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
-        $length = $rand(0, $size);
+        $length = $rand->rand(0, $size);
 
         $built = '';
         for ($i = 0; $i < $length; $i++) {
-            $built .= chr($rand(33, 126));
+            $built .= chr($rand->rand(33, 126));
         }
         return GeneratedValueSingle::fromJustValue($built, 'string');
     }

--- a/src/Generator/SubsetGenerator.php
+++ b/src/Generator/SubsetGenerator.php
@@ -4,10 +4,11 @@ namespace Eris\Generator;
 // TODO: dependency on ForAll is bad,
 // maybe inject the relative size?
 use Eris\Quantifier\ForAll;
+use Eris\Random\RandomRange;
 use Eris\Generator;
 
 /**
- * @param array $universe
+ * @param array $input
  * @return SubsetGenerator
  */
 function subset($input)
@@ -24,7 +25,7 @@ class SubsetGenerator implements Generator
         $this->universe = $universe;
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $relativeSize = $size / ForAll::DEFAULT_MAX_SIZE;
         $maximumSubsetIndex = floor(pow(2, count($this->universe)) * $relativeSize);

--- a/src/Generator/SubsetGenerator.php
+++ b/src/Generator/SubsetGenerator.php
@@ -24,11 +24,11 @@ class SubsetGenerator implements Generator
         $this->universe = $universe;
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         $relativeSize = $size / ForAll::DEFAULT_MAX_SIZE;
         $maximumSubsetIndex = floor(pow(2, count($this->universe)) * $relativeSize);
-        $subsetIndex = $rand(0, $maximumSubsetIndex);
+        $subsetIndex = $rand->rand(0, $maximumSubsetIndex);
         $binaryDescription = str_pad(decbin($subsetIndex), count($this->universe), "0", STR_PAD_LEFT);
         $subset = [];
         for ($i = 0; $i < strlen($binaryDescription); $i++) {

--- a/src/Generator/SuchThatGenerator.php
+++ b/src/Generator/SuchThatGenerator.php
@@ -43,7 +43,7 @@ class SuchThatGenerator implements Generator
         $this->maximumAttempts = $maximumAttempts;
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         $value = $this->generator->__invoke($size, $rand);
         $attempts = 0;

--- a/src/Generator/SuchThatGenerator.php
+++ b/src/Generator/SuchThatGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 use LogicException;
 use PHPUnit_Framework_Constraint;
 use PHPUnit\Framework\Constraint\Constraint;
@@ -43,7 +44,7 @@ class SuchThatGenerator implements Generator
         $this->maximumAttempts = $maximumAttempts;
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $value = $this->generator->__invoke($size, $rand);
         $attempts = 0;

--- a/src/Generator/TupleGenerator.php
+++ b/src/Generator/TupleGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 /**
  * One Generator for each member of the Tuple:
@@ -25,7 +24,6 @@ function tuple()
 class TupleGenerator implements Generator
 {
     private $generators;
-    private $size;
     private $numberOfGenerators;
 
     public function __construct(array $generators)
@@ -34,7 +32,7 @@ class TupleGenerator implements Generator
         $this->numberOfGenerators = count($generators);
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         $input = array_map(
             function ($generator) use ($size, $rand) {

--- a/src/Generator/TupleGenerator.php
+++ b/src/Generator/TupleGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 /**
  * One Generator for each member of the Tuple:
@@ -32,7 +33,7 @@ class TupleGenerator implements Generator
         $this->numberOfGenerators = count($generators);
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         $input = array_map(
             function ($generator) use ($size, $rand) {

--- a/src/Generator/VectorGenerator.php
+++ b/src/Generator/VectorGenerator.php
@@ -2,7 +2,6 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
-use DomainException;
 
 function vector($size, Generator $elementsGenerator)
 {
@@ -24,7 +23,7 @@ class VectorGenerator implements Generator
         $this->elementsGeneratorClass = get_class($generator);
     }
 
-    public function __invoke($size, $rand)
+    public function __invoke($size, \Eris\Random\RandomRange $rand)
     {
         return $this->generator->__invoke($size, $rand);
     }

--- a/src/Generator/VectorGenerator.php
+++ b/src/Generator/VectorGenerator.php
@@ -2,6 +2,7 @@
 namespace Eris\Generator;
 
 use Eris\Generator;
+use Eris\Random\RandomRange;
 
 function vector($size, Generator $elementsGenerator)
 {
@@ -23,7 +24,7 @@ class VectorGenerator implements Generator
         $this->elementsGeneratorClass = get_class($generator);
     }
 
-    public function __invoke($size, \Eris\Random\RandomRange $rand)
+    public function __invoke($size, RandomRange $rand)
     {
         return $this->generator->__invoke($size, $rand);
     }

--- a/src/Quantifier/ForAll.php
+++ b/src/Quantifier/ForAll.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 use Exception;
 use RuntimeException;
 use Eris\Listener;
+use Eris\Random\RandomRange;
 
 class ForAll
 {
@@ -36,7 +37,7 @@ class ForAll
     private $rand;
     private $shrinkingEnabled = true;
 
-    public function __construct(array $generators, $iterations, $shrinkerFactory, $shrinkerFactoryMethod, \Eris\Random\RandomRange $rand)
+    public function __construct(array $generators, $iterations, $shrinkerFactory, $shrinkerFactoryMethod, RandomRange $rand)
     {
         $this->generators = $this->generatorsFrom($generators);
         $this->iterations = $iterations;

--- a/src/Quantifier/ForAll.php
+++ b/src/Quantifier/ForAll.php
@@ -29,10 +29,14 @@ class ForAll
     private $terminationConditions = [];
     private $listeners = [];
     private $shrinkerFactoryMethod;
+
+    /**
+     * @var RandomRange
+     */
     private $rand;
     private $shrinkingEnabled = true;
 
-    public function __construct(array $generators, $iterations, $shrinkerFactory, $shrinkerFactoryMethod, $rand)
+    public function __construct(array $generators, $iterations, $shrinkerFactory, $shrinkerFactoryMethod, \Eris\Random\RandomRange $rand)
     {
         $this->generators = $this->generatorsFrom($generators);
         $this->iterations = $iterations;
@@ -167,8 +171,7 @@ class ForAll
             }
         } catch (Exception $e) {
             $redTestException = $e;
-            $wrap = (bool) getenv('ERIS_ORIGINAL_INPUT');
-            if ($wrap) {
+            if ((bool) getenv('ERIS_ORIGINAL_INPUT')) {
                 $message = "Original input: " . var_export($values, true) . PHP_EOL
                     . "Possibly shrinked input follows." . PHP_EOL;
                 throw new RuntimeException($message, -1, $e);

--- a/src/Random/MersenneTwister.php
+++ b/src/Random/MersenneTwister.php
@@ -43,27 +43,27 @@ class MersenneTwister implements Source
             $this->mt[$i] = ($this->f * (
                 $this->mt[$i - 1] ^ (($this->mt[$i - 1] >> ($this->w - 2)) & 0b11)
             ) + $i) & $this->wMask;
-            assert('$this->mt[$i] <= $this->wMask');
+            assert($this->mt[$i] <= $this->wMask);
         }
-        assert('count($this->mt) === 624');
+        assert(count($this->mt) === 624);
         return $this;
     }
 
     public function extractNumber()
     {
-        assert('$this->index <= $this->n');
+        assert($this->index <= $this->n);
         if ($this->index >= $this->n) {
             $this->twist();
         }
         $y = $this->mt[$this->index];
         $y = $y ^ (($y >> $this->u) & $this->d);
-        assert('$y <= 0xffffffff');
+        assert($y <= 0xffffffff);
         $y = $y ^ (($y << $this->s) & $this->b);
-        assert('$y <= 0xffffffff');
+        assert($y <= 0xffffffff);
         $y = $y ^ (($y << $this->t) & $this->c);
-        assert('$y <= 0xffffffff');
+        assert($y <= 0xffffffff);
         $y = $y ^ ($y >> $this->l);
-        assert('$y <= 0xffffffff');
+        assert($y <= 0xffffffff);
         $this->index = $this->index + 1;
         return $y & $this->wMask;
     }
@@ -78,9 +78,9 @@ class MersenneTwister implements Source
         for ($i = 0; $i <= $this->n - 1; $i++) {
             $x = ($this->mt[$i] & $this->upperMask)
                + (($this->mt[($i+1) % $this->n]) & $this->lowerMask);
-            assert('$x <= 0xffffffff');
+            assert($x <= 0xffffffff);
             $xA = $x >> 1;
-            assert('$xA <= 0x7fffffff');
+            assert($xA <= 0x7fffffff);
             if (($x % 2) != 0) {
                 $xA = $xA ^ $this->a;
             }

--- a/src/Random/MtRandSource.php
+++ b/src/Random/MtRandSource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Eris\Random;
+
+class MtRandSource implements Source
+{
+    /**
+     * Returns a random number between 0 and @see max().
+     * @return integer
+     */
+    public function extractNumber()
+    {
+        return mt_rand(0, $this->max());
+    }
+
+    /**
+     * @return integer
+     */
+    public function max()
+    {
+        return mt_getrandmax();
+    }
+
+    /**
+     * @param integer $seed
+     * @return self
+     */
+    public function seed($seed)
+    {
+        mt_srand($seed);
+        return $this;
+    }
+}

--- a/src/Random/RandSource.php
+++ b/src/Random/RandSource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Eris\Random;
+
+class RandSource implements Source
+{
+    /**
+     * Returns a random number between 0 and @see max().
+     * @return integer
+     */
+    public function extractNumber()
+    {
+        return rand(0, $this->max());
+    }
+
+    /**
+     * @return integer
+     */
+    public function max()
+    {
+        return getrandmax();
+    }
+
+    /**
+     * @param integer $seed
+     * @return self
+     */
+    public function seed($seed)
+    {
+        srand($seed);
+        return $this;
+    }
+}

--- a/src/Random/RandomRange.php
+++ b/src/Random/RandomRange.php
@@ -43,6 +43,9 @@ class RandomRange
             return $this->source->extractNumber();
         }
 
+        if ($lower > $upper) {
+            list($lower, $upper) = [$upper, $lower];
+        }
         $delta = $upper - $lower;
         $divisor = ($this->source->max()) / ($delta + 1);
 

--- a/src/Shrinker/Multiple.php
+++ b/src/Shrinker/Multiple.php
@@ -71,7 +71,7 @@ class Multiple implements Shrinker
             if ($this->timeLimit->hasBeenReached()) {
                 throw new \RuntimeException(
                     "Eris has reached the time limit for shrinking ($this->timeLimit), here it is presenting the simplest failure case." . PHP_EOL
-                    . "If you can afford to spend more time to find a simpler failing input, increase it with \$this->shrinkingTimeLimit(\$seconds).",
+                    . "If you can afford to spend more time to find a simpler failing input, increase it with the annotation \'@eris-shrink {seconds}\'.",
                     -1,
                     $exception
                 );

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -1,9 +1,15 @@
 <?php
 namespace Eris;
 
-use OutOfBoundsException;
+use BadMethodCallException;
 use DateInterval;
-use InvalidArgumentException;
+use Eris\Listener\MinimumEvaluations;
+use Eris\Quantifier\ForAll;
+use Eris\Quantifier\TimeBasedTerminationCondition;
+use Eris\Random\MtRandSource;
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+use Eris\Shrinker\ShrinkerFactory;
 
 trait TestTrait
 {
@@ -13,8 +19,10 @@ trait TestTrait
     private $iterations = 100;
     private $listeners = [];
     private $terminationConditions = [];
-    private $randFunction = 'rand';
-    private $seedFunction = 'srand';
+    /**
+     * @var RandomRange
+     */
+    private $randFunction;
     private $shrinkerFactoryMethod = 'multiple';
     protected $seed;
     protected $shrinkingTimeLimit;
@@ -36,8 +44,52 @@ trait TestTrait
      */
     public function erisSetup()
     {
-        $this->seedingRandomNumberGeneration();
-        $this->minimumEvaluationRatio(0.5);
+        $this->seed = intval(getenv('ERIS_SEED') ?: (microtime(true)*1000000));
+        if ($this->seed < 0) {
+            $this->seed *= -1;
+        }
+        $this->listeners = array_filter(
+            $this->listeners,
+            function ($listener) {
+                return !($listener instanceof MinimumEvaluations);
+            }
+        );
+        $tags = $this->getAnnotations();//from TestCase of PHPunit
+        $this->withRand($this->getAnnotationValue($tags, 'eris-method', 'rand', 'strval'));
+        $this->iterations = $this->getAnnotationValue($tags, 'eris-repeat', 100, 'intval');
+        $this->shrinkingTimeLimit = $this->getAnnotationValue($tags, 'eris-shrink', null, 'intval');
+        $this->listeners[] = MinimumEvaluations::ratio($this->getAnnotationValue($tags, 'eris-ratio', 50, 'floatval')/100);
+        $duration = $this->getAnnotationValue($tags, 'eris-duration', false, 'strval');
+        if ($duration) {
+            $terminationCondition = new TimeBasedTerminationCondition('time', new DateInterval($duration));
+            $this->listeners[] = $terminationCondition;
+            $this->terminationConditions[] = $terminationCondition;
+        }
+    }
+
+    /**
+     * @param array $annotations
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    private function getAnnotationValue(array $annotations, $key, $default, $cast)
+    {
+        $annotation = $this->getAnnotation($annotations, $key);
+        return isset($annotation[0])?$cast($annotation[0]):$default;
+    }
+
+    /**
+     * @param array $annotations
+     * @param string $key
+     * @return array
+     */
+    private function getAnnotation(array $annotations, $key)
+    {
+        if (isset($annotations['method'][$key])) {
+            return $annotations['method'][$key];
+        }
+        return isset($annotations['class'][$key])?$annotations['class'][$key]:[];
     }
 
     /**
@@ -48,81 +100,17 @@ trait TestTrait
         $this->dumpSeedForReproducing();
     }
 
-    private function seedingRandomNumberGeneration()
-    {
-        if ($seed = getenv('ERIS_SEED')) {
-            $this->seed = $seed;
-        } else {
-            $this->seed = (int) (microtime(true)*1000000);
-        }
-    }
-
     /**
      * Maybe: we could add --filter options to the command here,
      * since now the original command is printed.
      */
     private function dumpSeedForReproducing()
     {
-        if ($this->hasFailed()) {
-            global $argv;
-            $command = PHPUnitCommand::fromSeedAndName($this->seed, $this->toString());
-            echo PHP_EOL;
-            echo "Reproduce with:", PHP_EOL;
-            echo $command, PHP_EOL;
+        if (!$this->hasFailed()) {
+            return;
         }
-    }
-
-    /**
-     * @param float  from 0.0 to 1.0
-     * @return self
-     */
-    protected function minimumEvaluationRatio($ratio)
-    {
-        $this->filterOutListenersOfClass('Eris\\Listener\\MinimumEvaluations');
-        $this->listeners[] = Listener\MinimumEvaluations::ratio($ratio);
-        return $this;
-    }
-
-    private function filterOutListenersOfClass($className)
-    {
-        $this->listeners = array_filter(
-            $this->listeners,
-            function ($listener) use ($className) {
-                return !($listener instanceof $className);
-            }
-        );
-    }
-
-    /**
-     * @param integer|DateInterval
-     * @return self
-     */
-    protected function limitTo($limit)
-    {
-        if ($limit instanceof DateInterval) {
-            $interval = $limit;
-            $terminationCondition = new Quantifier\TimeBasedTerminationCondition('time', $interval);
-            $this->listeners[] = $terminationCondition;
-            $this->terminationConditions[] = $terminationCondition;
-        } elseif (is_integer($limit)) {
-            $this->iterations = $limit;
-        } else {
-            throw new InvalidArgumentException("The limit " . var_export($limit, true) . " is not valid. Please pass an integer or DateInterval.");
-        }
-        return $this;
-    }
-
-    /**
-     * The maximum time to spend trying to shrink the input after a failed test.
-     * The default is no limit.
-     *
-     * @param integer  in seconds
-     * @return self
-     */
-    protected function shrinkingTimeLimit($shrinkingTimeLimit)
-    {
-        $this->shrinkingTimeLimit = $shrinkingTimeLimit;
-        return $this;
+        $command = PHPUnitCommand::fromSeedAndName($this->seed, $this->toString());
+        echo PHP_EOL."Reproduce with:".PHP_EOL.$command.PHP_EOL;
     }
 
     /**
@@ -130,44 +118,33 @@ trait TestTrait
      */
     protected function withRand($randFunction)
     {
-        // TODO: invert and wrap rand, srand into objects?
-        if ($randFunction instanceof \Eris\Random\RandomRange) {
-            $this->randFunction = function ($lower = null, $upper = null) use ($randFunction) {
-                return $randFunction->rand($lower, $upper);
-            };
-            $this->seedFunction = function ($seed) use ($randFunction) {
-                return $randFunction->seed($seed);
-            };
+        if ($randFunction === 'mt_rand') {
+            $this->randFunction = new RandomRange(new MtRandSource());
+            return $this;
         }
-        if (is_callable($randFunction)) {
-            switch ($randFunction) {
-                case 'rand':
-                    $seedFunction = 'srand';
-                    break;
-                case 'mt_rand':
-                    $seedFunction = 'mt_srand';
-                    break;
-                default:
-                    throw new BadMethodCallException("When specifying random generators different from the standard ones, you must also pass a \$seedFunction callable that will be called to seed it.");
-            }
+        if ($randFunction === 'rand') {
+            $this->randFunction = new RandomRange(new RandSource());
+            return $this;
+        }
+        if ($randFunction instanceof RandomRange) {
             $this->randFunction = $randFunction;
-            $this->seedFunction = $seedFunction;
+            return $this;
         }
-        return $this;
+        throw new BadMethodCallException("When specifying random generators different from the standard ones, you must also pass a \$seedFunction callable that will be called to seed it.");
     }
 
     /**
      * forAll($generator1, $generator2, ...)
-     * @return Quantifier\ForAll
+     * @return ForAll
      */
     public function forAll()
     {
-        call_user_func($this->seedFunction, $this->seed);
+        $this->randFunction->seed($this->seed);
         $generators = func_get_args();
-        $quantifier = new Quantifier\ForAll(
+        $quantifier = new ForAll(
             $generators,
             $this->iterations,
-            new Shrinker\ShrinkerFactory([
+            new ShrinkerFactory([
                 'timeLimit' => $this->shrinkingTimeLimit,
             ]),
             $this->shrinkerFactoryMethod,

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -44,7 +44,7 @@ trait TestTrait
      */
     public function erisSetup()
     {
-        $this->seed = $this->seedFromEnv();
+        $this->seedingRandomNumberGeneration();
         $this->listeners = array_filter(
             $this->listeners,
             function ($listener) {
@@ -64,15 +64,15 @@ trait TestTrait
 
     /**
      * @internal
-     * @return int
+     * @return void
      */
-    private function seedFromEnv()
+    private function seedingRandomNumberGeneration()
     {
         $seed = intval(getenv('ERIS_SEED') ?: (microtime(true)*1000000));
         if ($seed < 0) {
             $seed *= -1;
         }
-        return $seed;
+        $this->seed = $seed;
     }
 
     /**

--- a/test/ExampleEnd2EndTest.php
+++ b/test/ExampleEnd2EndTest.php
@@ -96,7 +96,7 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
             var_export($this->theTest('testLengthPreservation'), true)
         );
         // one failure, two shrinking attempts: 2.0 + 2.0 == 4.0 seconds, plus some overhead
-        $this->assertLessThanOrEqual(5.0, $executionTime);
+        $this->assertLessThanOrEqual(9.0, $executionTime);
     }
 
     public function testDisableShrinkingTest()

--- a/test/ExampleEnd2EndTest.php
+++ b/test/ExampleEnd2EndTest.php
@@ -88,7 +88,7 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingTimeLimitTest()
     {
         $this->runExample('ShrinkingTimeLimitTest.php');
-        $this->assertTestsAreFailing(1);
+        $this->assertTestsAreFailing(2);
         $executionTime = (float) $this->theTest('testLengthPreservation')->attributes()['time'];
         $this->assertRegexp(
             '/Eris has reached the time limit for shrinking/',

--- a/test/ExampleEnd2EndTest.php
+++ b/test/ExampleEnd2EndTest.php
@@ -274,13 +274,15 @@ class ExampleEnd2EndTest extends \PHPUnit_Framework_TestCase
     {
         $this->testFile = $testFile;
         $examplesDir = realpath(__DIR__ . '/../examples');
-        $samplesTestCase = $examplesDir . '/' . $testFile;
+        $samplesTestCase = $examplesDir . DIRECTORY_SEPARATOR . $testFile;
         $logFile = tempnam(sys_get_temp_dir(), 'phpunit_log_');
         $environmentVariables = [];
         foreach ($this->environment as $name => $value) {
-            $environmentVariables[] .= "$name=$value";
+            $var = "$name=$value";
+            $environmentVariables[] = DIRECTORY_SEPARATOR==='\\' ? "set $var && " : $var;
         }
-        $phpunitCommand = implode(" ", $environmentVariables) . " vendor/bin/phpunit --log-junit $logFile $samplesTestCase";
+        $bin = "vendor".DIRECTORY_SEPARATOR."bin".DIRECTORY_SEPARATOR."phpunit";
+        $phpunitCommand = implode(" ", $environmentVariables) . " $bin --log-junit $logFile $samplesTestCase";
         exec($phpunitCommand, $output);
         $contentsOfXmlLog = file_get_contents($logFile);
         if (!$contentsOfXmlLog) {

--- a/test/Generator/AssociativeArrayGeneratorTest.php
+++ b/test/Generator/AssociativeArrayGeneratorTest.php
@@ -9,7 +9,7 @@ class AssociativeArrayGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->cipherGenerator = ElementsGenerator::fromArray([0, 1, 2]);
         $this->smallIntegerGenerator = new ChooseGenerator(0, 100);
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testConstructWithAnAssociativeArrayOfGenerators()

--- a/test/Generator/AssociativeArrayGeneratorTest.php
+++ b/test/Generator/AssociativeArrayGeneratorTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class AssociativeArrayGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
@@ -9,7 +12,7 @@ class AssociativeArrayGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->cipherGenerator = ElementsGenerator::fromArray([0, 1, 2]);
         $this->smallIntegerGenerator = new ChooseGenerator(0, 100);
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testConstructWithAnAssociativeArrayOfGenerators()

--- a/test/Generator/BindGeneratorTest.php
+++ b/test/Generator/BindGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class BindGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
     
     public function testGeneratesAGeneratedValueObject()

--- a/test/Generator/BindGeneratorTest.php
+++ b/test/Generator/BindGeneratorTest.php
@@ -6,7 +6,7 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
     
     public function testGeneratesAGeneratedValueObject()

--- a/test/Generator/BooleanGeneratorTest.php
+++ b/test/Generator/BooleanGeneratorTest.php
@@ -5,7 +5,7 @@ class BooleanGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
     
     public function testRandomlyPicksTrueOrFalse()

--- a/test/Generator/BooleanGeneratorTest.php
+++ b/test/Generator/BooleanGeneratorTest.php
@@ -1,11 +1,14 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class BooleanGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
     
     public function testRandomlyPicksTrueOrFalse()

--- a/test/Generator/CharacterGeneratorTest.php
+++ b/test/Generator/CharacterGeneratorTest.php
@@ -6,7 +6,7 @@ class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 0;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testBasicAsciiCharacterGenerators()

--- a/test/Generator/CharacterGeneratorTest.php
+++ b/test/Generator/CharacterGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class CharacterGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 0;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testBasicAsciiCharacterGenerators()

--- a/test/Generator/ChooseGeneratorTest.php
+++ b/test/Generator/ChooseGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 0; // ignored by this kind of generator
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testPicksRandomlyAnIntegerAmongBoundaries()

--- a/test/Generator/ChooseGeneratorTest.php
+++ b/test/Generator/ChooseGeneratorTest.php
@@ -6,7 +6,7 @@ class ChooseGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 0; // ignored by this kind of generator
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testPicksRandomlyAnIntegerAmongBoundaries()

--- a/test/Generator/ConstantGeneratorTest.php
+++ b/test/Generator/ConstantGeneratorTest.php
@@ -6,7 +6,7 @@ class ConstantGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 0;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testPicksAlwaysTheValue()

--- a/test/Generator/ConstantGeneratorTest.php
+++ b/test/Generator/ConstantGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class ConstantGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 0;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testPicksAlwaysTheValue()

--- a/test/Generator/DateGeneratorTest.php
+++ b/test/Generator/DateGeneratorTest.php
@@ -8,7 +8,7 @@ class DateGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testGenerateDateTimeObjectsInTheGivenInterval()

--- a/test/Generator/DateGeneratorTest.php
+++ b/test/Generator/DateGeneratorTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
 use DateTime;
 
 class DateGeneratorTest extends \PHPUnit_Framework_TestCase
@@ -8,7 +10,7 @@ class DateGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testGenerateDateTimeObjectsInTheGivenInterval()

--- a/test/Generator/ElementsGeneratorTest.php
+++ b/test/Generator/ElementsGeneratorTest.php
@@ -6,7 +6,7 @@ class ElementsGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testGeneratesOnlyArgumentsInsideTheGivenArray()

--- a/test/Generator/ElementsGeneratorTest.php
+++ b/test/Generator/ElementsGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class ElementsGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testGeneratesOnlyArgumentsInsideTheGivenArray()

--- a/test/Generator/FloatGeneratorTest.php
+++ b/test/Generator/FloatGeneratorTest.php
@@ -6,7 +6,7 @@ class FloatGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 300;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testPicksUniformelyPositiveAndNegativeFloatNumbers()

--- a/test/Generator/FloatGeneratorTest.php
+++ b/test/Generator/FloatGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class FloatGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 300;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testPicksUniformelyPositiveAndNegativeFloatNumbers()

--- a/test/Generator/FrequencyGeneratorTest.php
+++ b/test/Generator/FrequencyGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class FrequencyGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testEqualProbability()

--- a/test/Generator/FrequencyGeneratorTest.php
+++ b/test/Generator/FrequencyGeneratorTest.php
@@ -6,7 +6,7 @@ class FrequencyGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testEqualProbability()

--- a/test/Generator/IntegerGeneratorTest.php
+++ b/test/Generator/IntegerGeneratorTest.php
@@ -6,7 +6,7 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testPicksRandomlyAnInteger()

--- a/test/Generator/IntegerGeneratorTest.php
+++ b/test/Generator/IntegerGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testPicksRandomlyAnInteger()

--- a/test/Generator/MapGeneratorTest.php
+++ b/test/Generator/MapGeneratorTest.php
@@ -6,7 +6,7 @@ class MapGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
     
     public function testGeneratesAGeneratedValueObject()

--- a/test/Generator/MapGeneratorTest.php
+++ b/test/Generator/MapGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class MapGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
     
     public function testGeneratesAGeneratedValueObject()

--- a/test/Generator/NamesGeneratorTest.php
+++ b/test/Generator/NamesGeneratorTest.php
@@ -5,7 +5,7 @@ class NamesGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
     
     public function testItRespectsTheGenerationSize()

--- a/test/Generator/NamesGeneratorTest.php
+++ b/test/Generator/NamesGeneratorTest.php
@@ -1,11 +1,14 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class NamesGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
     
     public function testItRespectsTheGenerationSize()

--- a/test/Generator/OneOfGeneratorTest.php
+++ b/test/Generator/OneOfGeneratorTest.php
@@ -7,7 +7,7 @@ class OneOfGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->singleElementGenerator = new ChooseGenerator(0, 100);
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testConstructWithAnArrayOfGenerators()

--- a/test/Generator/OneOfGeneratorTest.php
+++ b/test/Generator/OneOfGeneratorTest.php
@@ -1,13 +1,16 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class OneOfGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->singleElementGenerator = new ChooseGenerator(0, 100);
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testConstructWithAnArrayOfGenerators()

--- a/test/Generator/RegexGeneratorTest.php
+++ b/test/Generator/RegexGeneratorTest.php
@@ -18,7 +18,7 @@ class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     /**

--- a/test/Generator/RegexGeneratorTest.php
+++ b/test/Generator/RegexGeneratorTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public static function supportedRegexes()
@@ -18,7 +21,7 @@ class RegexGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     /**

--- a/test/Generator/SequenceGeneratorTest.php
+++ b/test/Generator/SequenceGeneratorTest.php
@@ -1,13 +1,16 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class SequenceGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 100;
         $this->singleElementGenerator = new ChooseGenerator(10, 100);
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testRespectsGenerationSize()

--- a/test/Generator/SequenceGeneratorTest.php
+++ b/test/Generator/SequenceGeneratorTest.php
@@ -7,7 +7,7 @@ class SequenceGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->size = 100;
         $this->singleElementGenerator = new ChooseGenerator(10, 100);
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testRespectsGenerationSize()

--- a/test/Generator/SetGeneratorTest.php
+++ b/test/Generator/SetGeneratorTest.php
@@ -1,13 +1,16 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class SetGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 100;
         $this->singleElementGenerator = new ChooseGenerator(10, 100);
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testRespectsGenerationSize()

--- a/test/Generator/SetGeneratorTest.php
+++ b/test/Generator/SetGeneratorTest.php
@@ -7,7 +7,7 @@ class SetGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->size = 100;
         $this->singleElementGenerator = new ChooseGenerator(10, 100);
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testRespectsGenerationSize()

--- a/test/Generator/StringGeneratorTest.php
+++ b/test/Generator/StringGeneratorTest.php
@@ -5,7 +5,7 @@ class StringGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
     
     public function testRandomlyPicksLengthAndCharacters()

--- a/test/Generator/StringGeneratorTest.php
+++ b/test/Generator/StringGeneratorTest.php
@@ -1,11 +1,14 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class StringGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
     
     public function testRandomlyPicksLengthAndCharacters()

--- a/test/Generator/SubsetGeneratorTest.php
+++ b/test/Generator/SubsetGeneratorTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
 use Eris\Quantifier\ForAll;
 
 class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
@@ -10,7 +12,7 @@ class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->universe = ['a', 'b', 'c', 'd', 'e'];
         $this->generator = new SubsetGenerator($this->universe);
         $this->size = 100;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
     
     public function testScalesGenerationSizeToTouchAllPossibleSubsets()

--- a/test/Generator/SubsetGeneratorTest.php
+++ b/test/Generator/SubsetGeneratorTest.php
@@ -10,7 +10,7 @@ class SubsetGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->universe = ['a', 'b', 'c', 'd', 'e'];
         $this->generator = new SubsetGenerator($this->universe);
         $this->size = 100;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
     
     public function testScalesGenerationSizeToTouchAllPossibleSubsets()

--- a/test/Generator/SuchThatGeneratorTest.php
+++ b/test/Generator/SuchThatGeneratorTest.php
@@ -6,7 +6,7 @@ class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
     
     public function testGeneratesAGeneratedValueObject()

--- a/test/Generator/SuchThatGeneratorTest.php
+++ b/test/Generator/SuchThatGeneratorTest.php
@@ -1,12 +1,15 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class SuchThatGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
     
     public function testGeneratesAGeneratedValueObject()

--- a/test/Generator/TupleGeneratorTest.php
+++ b/test/Generator/TupleGeneratorTest.php
@@ -1,13 +1,16 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         $this->generatorForSingleElement = new ChooseGenerator(0, 100);
         $this->size = 10;
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     private function assertInSingleElementGenerator($value)

--- a/test/Generator/TupleGeneratorTest.php
+++ b/test/Generator/TupleGeneratorTest.php
@@ -7,7 +7,7 @@ class TupleGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->generatorForSingleElement = new ChooseGenerator(0, 100);
         $this->size = 10;
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     private function assertInSingleElementGenerator($value)

--- a/test/Generator/VectorGeneratorTest.php
+++ b/test/Generator/VectorGeneratorTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Eris\Generator;
 
+use Eris\Random\RandomRange;
+use Eris\Random\RandSource;
+
 class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
@@ -13,7 +16,7 @@ class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
             $acc = $acc + $item;
             return $acc;
         };
-        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
+        $this->rand = new RandomRange(new RandSource());
     }
 
     public function testGeneratesVectorWithGivenSizeAndElementsFromGivenGenerator()

--- a/test/Generator/VectorGeneratorTest.php
+++ b/test/Generator/VectorGeneratorTest.php
@@ -13,7 +13,7 @@ class VectorGeneratorTest extends \PHPUnit_Framework_TestCase
             $acc = $acc + $item;
             return $acc;
         };
-        $this->rand = 'rand';
+        $this->rand = new \Eris\Random\RandomRange(new \Eris\Random\RandSource());
     }
 
     public function testGeneratesVectorWithGivenSizeAndElementsFromGivenGenerator()

--- a/test/Listener/LogTest.php
+++ b/test/Listener/LogTest.php
@@ -3,10 +3,10 @@ namespace Eris\Listener;
 
 class LogTest extends \PHPUnit_Framework_TestCase
 {
-    private $timezone;
+    private $originalTimezone;
     protected function setUp()
     {
-        $this->timezone = date_default_timezone_get();
+        $this->originalTimezone = date_default_timezone_get();
         $this->file = sys_get_temp_dir().'/eris-log-unit-test.log';
         $this->time = function () {
             return 1300000000;
@@ -18,7 +18,7 @@ class LogTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->log->endPropertyVerification(null, null);
-        date_default_timezone_set($this->timezone);
+        date_default_timezone_set($this->originalTimezone);
     }
 
     public function testWritesALineForEachIterationShowingItsIndex()

--- a/test/Listener/LogTest.php
+++ b/test/Listener/LogTest.php
@@ -20,7 +20,7 @@ class LogTest extends \PHPUnit_Framework_TestCase
         $this->log->endPropertyVerification(null, null);
         date_default_timezone_set($this->timezone);
     }
-    
+
     public function testWritesALineForEachIterationShowingItsIndex()
     {
         $this->log->newGeneration([23], 42);

--- a/test/Listener/LogTest.php
+++ b/test/Listener/LogTest.php
@@ -1,22 +1,24 @@
 <?php
 namespace Eris\Listener;
 
-use Eris\Generator\GeneratedValueSingle;
-
 class LogTest extends \PHPUnit_Framework_TestCase
 {
+    private $timezone;
     protected function setUp()
     {
-        $this->file = '/tmp/eris-log-unit-test.log';
+        $this->timezone = date_default_timezone_get();
+        $this->file = sys_get_temp_dir().'/eris-log-unit-test.log';
         $this->time = function () {
             return 1300000000;
         };
         $this->log = new Log($this->file, $this->time, 1234);
+        date_default_timezone_set('UTC');
     }
 
     public function tearDown()
     {
         $this->log->endPropertyVerification(null, null);
+        date_default_timezone_set($this->timezone);
     }
     
     public function testWritesALineForEachIterationShowingItsIndex()


### PR DESCRIPTION
The way I use annotations to replace protected methods is obviously breaking, if that is undesired I could add the methods back in.

- enabling php7.2 refs #116
- replacing some configuration with annotations refs #105
- moving rand and mt_rand into Source-Implementations
- removing unused use statements
- replacing os specific tmp-dir with function calls
- fixing env-setting on windows
- handling int overflow for seeds on 32bit systems
- adjusting documentation