### PR TITLE
fix for PHP 7.4 string index access

### DIFF
--- a/src/Generator/SubsetGenerator.php
+++ b/src/Generator/SubsetGenerator.php
@@ -33,7 +33,7 @@ class SubsetGenerator implements Generator
         $binaryDescription = str_pad(decbin($subsetIndex), count($this->universe), "0", STR_PAD_LEFT);
         $subset = [];
         for ($i = 0; $i < strlen($binaryDescription); $i++) {
-            $elementPresent = $binaryDescription{$i};
+            $elementPresent = $binaryDescription[$i];
             if ($elementPresent == "1") {
                 $subset[] = $this->universe[$i];
             }

--- a/test/Generator/StringGeneratorTest.php
+++ b/test/Generator/StringGeneratorTest.php
@@ -64,7 +64,7 @@ class StringGeneratorTest extends \PHPUnit_Framework_TestCase
     private function accumulateUsedChars(array $usedChars, $value)
     {
         for ($j = 0; $j < strlen($value); $j++) {
-            $char = $value{$j};
+            $char = $value[$j];
             if (!isset($usedChars[$char])) {
                 $usedChars[$char] = 0;
             }


### PR DESCRIPTION
This PR fixes two instances of curly bracers used for array and/or string index access. This has been deprecated in PHP 7.4:

see https://wiki.php.net/rfc/deprecate_curly_braces_array_access