### PR TITLE
Fixes build for old php version and hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,39 @@
+os: linux
 language: php
-
-sudo: false
 
 env:
   global:
     - secure: "Vbdts9k+dvnzAmuRPXMDZLw2+s+4q0Ijdbx97rCBefrBbG+6elfR0ao60135QVAoiQxTR//Iz6ZZbsFfTTt9Qo4SVvulzepuLz4lDQmO1BTeKlAWyM650+uFDP39iRY+i6Z7w5RGZzw4F3Sjw8N4kcxdrkkJLH4p9ZQkA5uSkzg="
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - php: 5.5 # PHPUnit 4.8
+      dist: trusty
     - php: 5.6 # PHPUnit 5.7
       env: WITH_CS=true
     - php: 7 # PHPUnit 6.x
     - php: 7.1 # PHPUnit 7.x
     - php: 7.2 # PHPUnit 7.x
     - php: 7.3 # PHPUnit 7.x
-    - php: hhvm
-      env: SKIP_LINT_TEST_CASES=1
-      sudo: required
+    - php: hhvm-3.30 # PHPUnit 5.7
       dist: trusty
-      group: edge
+      env:
+        - SKIP_LINT_TEST_CASES=1
+        - USE_HHVM=true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ -z "$USE_HHVM" || "$USE_HHVM" != "true" ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" && "$GITHUB_TOKEN" != "" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
+  - if [[ -z "$USE_HHVM" || "$USE_HHVM" != "true" ]] && [[ "$GITHUB_TOKEN" != "" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
   - composer validate
 
 install:
+  - if [[ "$USE_HHVM" == "true" ]]; then composer require --dev phpunit/phpunit ^5.7; fi # hhvm and phpunit 7 are incompatible
   - composer install --prefer-dist
 
 script:
@@ -45,4 +46,4 @@ notifications:
       - https://webhooks.gitter.im/e/b78839c0066e95e47dab
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_start: never     # default: never

--- a/examples/LimitToTest.php
+++ b/examples/LimitToTest.php
@@ -12,8 +12,8 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     public function testNumberOfIterationsCanBeConfigured()
     {
         $this->forAll(
-                Generator\int()
-            )
+            Generator\int()
+        )
             ->then(function ($value) {
                 $this->assertInternalType('integer', $value);
             });
@@ -56,8 +56,8 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     public function testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnoredFromAnnotation()
     {
         $this->forAll(
-                Generator\int()
-            )
+            Generator\int()
+        )
             ->then(function ($value) {
                 usleep(100 * 1000);
                 $this->assertTrue(true);

--- a/examples/ShrinkingTest.php
+++ b/examples/ShrinkingTest.php
@@ -9,8 +9,8 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingAString()
     {
         $this->forAll(
-                Generator\string()
-            )
+            Generator\string()
+        )
             ->then(function ($string) {
                 var_dump($string);
                 $this->assertNotContains('B', $string);
@@ -20,8 +20,8 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingRespectsAntecedents()
     {
         $this->forAll(
-                Generator\choose(0, 20)
-            )
+            Generator\choose(0, 20)
+        )
             ->when(function ($number) {
                 return $number > 10;
             })


### PR DESCRIPTION
Hi @giorgiosironi,

this PR is intended to be a fix to the build problems that are blocking #125 

Here's what I've done:

- some cs fix
- fixed php 5.5 build (which is available only with `dist: trusty` on travis)
- removed some deprecation from `.travis.yml` just to keep it up to date
- forced HHVM to 3.30 version, which will be [the last one supporting PHP](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html)
- forced the use of phpunit 5.7 with hhvm as it's [incompatible with phpunit 7](https://docs.travis-ci.com/user/languages/php/#hhvm-versions-are-available-on-trusty-only)

I hope this will be useful