### PR TITLE
Allow shrink() to receive GeneratedValueOptions

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -1,6 +1,7 @@
 <?php
 namespace Eris;
 
+use Eris\Generator\GeneratedValue;
 use Eris\Generator\GeneratedValueSingle;
 
 /**
@@ -20,8 +21,8 @@ interface Generator
      * - returning the same GeneratedValueSingle passed in
      * - returning an empty GeneratedValueOptions
      *
-     * @param GeneratedValueSingle<T>
-     * @return GeneratedValueSingle<T>|GeneratedValueOptions<T>
+     * @param GeneratedValue<T>
+     * @return GeneratedValue<T>
      */
-    public function shrink(GeneratedValueSingle $element);
+    public function shrink(GeneratedValue $element);
 }

--- a/src/Generator/AssociativeArrayGenerator.php
+++ b/src/Generator/AssociativeArrayGenerator.php
@@ -29,7 +29,7 @@ class AssociativeArrayGenerator implements Generator
         return $this->mapToAssociativeArray($tuple);
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         $input = $element->input();
         $shrunkInput = $this->tupleGenerator->shrink($input);

--- a/src/Generator/BindGenerator.php
+++ b/src/Generator/BindGenerator.php
@@ -34,7 +34,7 @@ class BindGenerator implements Generator
         );
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         list($outerGeneratorValue, $innerGeneratorValue) = $element->input();
         // TODO: shrink also the second generator

--- a/src/Generator/BooleanGenerator.php
+++ b/src/Generator/BooleanGenerator.php
@@ -19,7 +19,7 @@ class BooleanGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($booleanValues[$randomIndex], 'boolean');
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         return GeneratedValueSingle::fromJustValue(false);
     }

--- a/src/Generator/CharacterGenerator.php
+++ b/src/Generator/CharacterGenerator.php
@@ -55,7 +55,7 @@ class CharacterGenerator implements Generator
         return GeneratedValueSingle::fromJustValue(chr($rand->rand($this->lowerLimit, $this->upperLimit)), 'character');
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         $shrinkedValue = chr($this->shrinkingProgression->next(ord($element->unbox())));
         return GeneratedValueSingle::fromJustValue($shrinkedValue, 'character');

--- a/src/Generator/ChooseGenerator.php
+++ b/src/Generator/ChooseGenerator.php
@@ -49,7 +49,7 @@ class ChooseGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($value, 'choose');
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         if ($element->input() > $this->shrinkTarget) {
             return GeneratedValueSingle::fromJustValue($element->input() - 1);

--- a/src/Generator/ConstantGenerator.php
+++ b/src/Generator/ConstantGenerator.php
@@ -32,7 +32,7 @@ class ConstantGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($this->value, 'constant');
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         return GeneratedValueSingle::fromJustValue($this->value, 'constant');
     }

--- a/src/Generator/DateGenerator.php
+++ b/src/Generator/DateGenerator.php
@@ -51,7 +51,7 @@ class DateGenerator implements Generator
         );
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         $timeOffset = $element->unbox()->getTimestamp() - $this->lowerLimit->getTimestamp();
         $halvedOffset = floor($timeOffset / 2);

--- a/src/Generator/ElementsGenerator.php
+++ b/src/Generator/ElementsGenerator.php
@@ -35,7 +35,7 @@ class ElementsGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($this->domain[$index], 'elements');
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         return $element;
     }

--- a/src/Generator/FloatGenerator.php
+++ b/src/Generator/FloatGenerator.php
@@ -27,7 +27,7 @@ class FloatGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($signedValue, 'float');
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         $value = $element->unbox();
 

--- a/src/Generator/FrequencyGenerator.php
+++ b/src/Generator/FrequencyGenerator.php
@@ -56,7 +56,7 @@ class FrequencyGenerator implements Generator
         );
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         $input = $element->input();
         $originalGeneratorIndex = $input['generator'];

--- a/src/Generator/GeneratedValue.php
+++ b/src/Generator/GeneratedValue.php
@@ -6,4 +6,20 @@ use IteratorAggregate;
 
 interface GeneratedValue extends IteratorAggregate, Countable
 {
+    /**
+     * @param callable $applyToValue
+     * @param string $generatorName
+     * @return GeneratedValue
+     */
+    public function map(callable $applyToValue, $generatorName);
+
+    /**
+     * @return mixed
+     */
+    public function input();
+
+    /**
+     * @return mixed
+     */
+    public function unbox();
 }

--- a/src/Generator/GeneratedValueOptions.php
+++ b/src/Generator/GeneratedValueOptions.php
@@ -73,7 +73,7 @@ class GeneratedValueOptions implements GeneratedValue
         ));
     }
 
-    public function remove(GeneratedValueSingle $value)
+    public function remove(GeneratedValue $value)
     {
         $generatedValues = $this->generatedValues;
         $index = array_search($value, $generatedValues);

--- a/src/Generator/IntegerGenerator.php
+++ b/src/Generator/IntegerGenerator.php
@@ -75,7 +75,7 @@ class IntegerGenerator implements Generator
         );
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         $mapFn = $this->mapFn;
         $element = $element->input();

--- a/src/Generator/MapGenerator.php
+++ b/src/Generator/MapGenerator.php
@@ -30,7 +30,7 @@ class MapGenerator implements Generator
         );
     }
 
-    public function shrink(GeneratedValueSingle $value)
+    public function shrink(GeneratedValue $value)
     {
         $input = $value->input();
         $shrunkInput = $this->generator->shrink($input);

--- a/src/Generator/NamesGenerator.php
+++ b/src/Generator/NamesGenerator.php
@@ -45,7 +45,7 @@ class NamesGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($candidateNames[$index], 'names');
     }
 
-    public function shrink(GeneratedValueSingle $value)
+    public function shrink(GeneratedValue $value)
     {
         $candidateNames = $this->filterDataSet(
             $this->lengthSlightlyLessThan(strlen($value->unbox()))

--- a/src/Generator/OneOfGenerator.php
+++ b/src/Generator/OneOfGenerator.php
@@ -26,7 +26,7 @@ class OneOfGenerator implements Generator
         return $this->generator->__invoke($size, $rand);
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         return $this->generator->shrink($element);
     }

--- a/src/Generator/RegexGenerator.php
+++ b/src/Generator/RegexGenerator.php
@@ -46,7 +46,7 @@ class RegexGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($result, 'regex');
     }
 
-    public function shrink(GeneratedValueSingle $value)
+    public function shrink(GeneratedValue $value)
     {
         return $value;
     }

--- a/src/Generator/SequenceGenerator.php
+++ b/src/Generator/SequenceGenerator.php
@@ -28,7 +28,7 @@ class SequenceGenerator implements Generator
         return $this->vector($sequenceLength)->__invoke($size, $rand);
     }
 
-    public function shrink(GeneratedValueSingle $sequence)
+    public function shrink(GeneratedValue $sequence)
     {
         $options = [];
         if (count($sequence->unbox()) > 0) {

--- a/src/Generator/SetGenerator.php
+++ b/src/Generator/SetGenerator.php
@@ -40,7 +40,7 @@ class SetGenerator implements Generator
         return GeneratedValueSingle::fromValueAndInput($set, $input, 'set');
     }
 
-    public function shrink(GeneratedValueSingle $set)
+    public function shrink(GeneratedValue $set)
     {
         if (count($set->input()) === 0) {
             return $set;

--- a/src/Generator/StringGenerator.php
+++ b/src/Generator/StringGenerator.php
@@ -22,7 +22,7 @@ class StringGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($built, 'string');
     }
 
-    public function shrink(GeneratedValueSingle $element)
+    public function shrink(GeneratedValue $element)
     {
         if ($element->unbox() === '') {
             return $element;

--- a/src/Generator/SubsetGenerator.php
+++ b/src/Generator/SubsetGenerator.php
@@ -42,7 +42,7 @@ class SubsetGenerator implements Generator
         return GeneratedValueSingle::fromJustValue($subset, 'subset');
     }
 
-    public function shrink(GeneratedValueSingle $set)
+    public function shrink(GeneratedValue $set)
     {
         // TODO: see SetGenerator::shrink()
         if (count($set->unbox()) === 0) {

--- a/src/Generator/SuchThatGenerator.php
+++ b/src/Generator/SuchThatGenerator.php
@@ -58,7 +58,7 @@ class SuchThatGenerator implements Generator
         return $value;
     }
 
-    public function shrink(GeneratedValueSingle $value)
+    public function shrink(GeneratedValue $value)
     {
         $shrunk = $this->generator->shrink($value);
         $attempts = 0;

--- a/src/Generator/TupleGenerator.php
+++ b/src/Generator/TupleGenerator.php
@@ -90,7 +90,7 @@ class TupleGenerator implements Generator
         }
     }
 
-    public function shrink(GeneratedValueSingle $tuple)
+    public function shrink(GeneratedValue $tuple)
     {
         $input = $tuple->input();
 

--- a/src/Generator/VectorGenerator.php
+++ b/src/Generator/VectorGenerator.php
@@ -29,7 +29,7 @@ class VectorGenerator implements Generator
         return $this->generator->__invoke($size, $rand);
     }
 
-    public function shrink(GeneratedValueSingle $vector)
+    public function shrink(GeneratedValue $vector)
     {
         return $this->generator->shrink($vector);
     }

--- a/test/Generator/BindGeneratorTest.php
+++ b/test/Generator/BindGeneratorTest.php
@@ -76,6 +76,20 @@ class BindGeneratorTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testShrinkBindGeneratorWithCompositeValue()
+    {
+        $bindGenerator     = new BindGenerator(
+            new ChooseGenerator(0, 5),
+            function ($n) {
+                return new TupleGenerator([$n]);
+            }
+        );
+        $generatedValue    = $bindGenerator->__invoke($this->size, $this->rand);
+        $firstShrunkValue  = $bindGenerator->shrink($generatedValue);
+        $secondShrunkValue = $bindGenerator->shrink($firstShrunkValue);
+        $this->assertInstanceOf('\Eris\Generator\GeneratedValue', $secondShrunkValue);
+    }
+
     private function assertIsAnArrayOfX0OrX1Elements(array $value)
     {
         $this->assertTrue(


### PR DESCRIPTION
## Rationale

Bugfix allowing multiple shrink steps to be executed on generators that return multiple values when used in a bind generator.

A test for the failing scenario is included in the PR in
`\Eris\Generator\BindGeneratorTest::testShrinkBindGeneratorWithCompositeValue`

## Description

Both `\Eris\Generator\GeneratedValueOptions` and `\Eris\Generator\GeneratedValueSingle` implement the interface `\Eris\Generator\GeneratedValue`.  
Until now `GeneratedValue` was only a marker interface without any methods.  
This PR adds the public methods shared by `GeneratedValueSingle` and `GeneratedValueOptions` to the interface, and changes the argument type of `public function shrink;` to `\Eris\Generator\GeneratedValue`.

New `GeneratedValue` methods:  
* `public function map(callable $applyToValue, $generatorName);`
* `public function input();`
* `public function unbox();`

New signature of `Generator::shrink`:  
`public function shrink(GeneratedValue $element);`

### Backward compatibility
This PR contains quite some backward compatibility breaking changes.  
However, they only are for what I would consider the internal API. The usual user API is not affected.

### Alternative Implementations
Most BC breaks could have been avoided by having `GeneratedValueOptions` inherit from `GeneratedValueSingle`.
However, even though this change would allow backward compatibility to be maintained, I don't think introducing inheritance is a good idea.  
Some methods would be inherited without being needed, but mostly because it would limit the ability to evolve `GeneratedValueSingle` in future.

Another approach would be to introduce a new interface, maybe `ShrinkableValue`(?), containing the required methods. Then both or the generated value classes could implement this new interface in addition to `GeneratedInterface`.
The argument to `Generator::shrink` would need to be changed to this new type, too.  
The benefit of this approach would be that existing third party implementations of `GeneratedValue` would not be broken,  
The `shrink` signature change would still be backward incompatible.  
This approach seems bloaty to me, and it doesn't avoid all BC breaks.

I suggest adding the shared methods to `GeneratedValue` directly and
changing the `shrink` argument type, because I think that approach captures the
intended design the best.

Reference issue #124 