### PR TITLE
Allow specifying the generator size when sampling

### DIFF
--- a/src/Sample.php
+++ b/src/Sample.php
@@ -9,15 +9,17 @@ class Sample
 
     private $generator;
     private $rand;
+    private $size;
     private $collected = [];
 
-    public static function of($generator, $rand)
+    public static function of($generator, $rand, $size = null)
     {
-        return new self($generator, $rand);
+        return new self($generator, $rand, $size);
     }
 
-    private function __construct($generator, $rand)
+    private function __construct($generator, $rand, $size = null)
     {
+        $this->size = isset($size) ? (int) $size : self::DEFAULT_SIZE;
         $this->generator = $generator;
         $this->rand = $rand;
     }
@@ -25,7 +27,7 @@ class Sample
     public function repeat($times)
     {
         for ($i = 0; $i < $times; $i++) {
-            $this->collected[] = $this->generator->__invoke(self::DEFAULT_SIZE, $this->rand)->unbox();
+            $this->collected[] = $this->generator->__invoke($this->size, $this->rand)->unbox();
         }
         return $this;
     }
@@ -33,7 +35,7 @@ class Sample
     public function shrink($nextValue = null)
     {
         if ($nextValue === null) {
-            $nextValue = $this->generator->__invoke(self::DEFAULT_SIZE, $this->rand);
+            $nextValue = $this->generator->__invoke($this->size, $this->rand);
         }
         $this->collected[] = $nextValue->unbox();
         while ($value = $this->generator->shrink($nextValue)) {

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -229,16 +229,16 @@ trait TestTrait
     /**
      * @return Sample
      */
-    public function sample(Generator $generator, $times = 10)
+    public function sample(Generator $generator, $times = 10, $size = null)
     {
-        return Sample::of($generator, $this->randRange)->repeat($times);
+        return Sample::of($generator, $this->randRange, $size)->repeat($times);
     }
 
     /**
      * @return Sample
      */
-    public function sampleShrink(Generator $generator, $fromValue = null)
+    public function sampleShrink(Generator $generator, $fromValue = null, $size = null)
     {
-        return Sample::of($generator, $this->randRange)->shrink($fromValue);
+        return Sample::of($generator, $this->randRange, $size)->shrink($fromValue);
     }
 }

--- a/test/SampleTest.php
+++ b/test/SampleTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Eris;
+
+class SampleTest extends \PHPUnit_Framework_TestCase
+{
+    use TestTrait;
+    
+    public function testWithGeneratorSize()
+    {
+        $times         = 100;
+        $generatorSize = 100;
+        $generator     = Generator\suchThat(function ($n) {
+            return $n > 10;
+        }, Generator\nat());
+        $sample        = $this->sample($generator, $times, $generatorSize);
+        $this->assertNotEmpty(count($sample->collected()));
+    }
+}


### PR DESCRIPTION
This PR doesn't contain any BC breaks, unless someone has overridden `\Eris\Sample` (which is not part of the intended user API as far as I can tell).

Closes https://github.com/giorgiosironi/eris/issues/128