### PR TITLE
Box BooleanGenerator shrink return value

### DIFF
--- a/src/Generator/BooleanGenerator.php
+++ b/src/Generator/BooleanGenerator.php
@@ -21,6 +21,6 @@ class BooleanGenerator implements Generator
 
     public function shrink(GeneratedValueSingle $element)
     {
-        return false;
+        return GeneratedValueSingle::fromJustValue(false);
     }
 }

--- a/test/Generator/BooleanGeneratorTest.php
+++ b/test/Generator/BooleanGeneratorTest.php
@@ -25,7 +25,7 @@ class BooleanGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new BooleanGenerator();
         for ($i = 0; $i < 10; $i++) {
             $generatedValue = $generator($_size = 10, $this->rand);
-            $this->assertFalse($generator->shrink($generatedValue));
+            $this->assertFalse($generator->shrink($generatedValue)->unbox());
         }
     }
 }


### PR DESCRIPTION
The `\Eris\Generator\BooleanGenerator::shrink` method currently returns
the unboxed value `false`.

This PR makes the return value a `\Eris\Generator\GeneratedValueSingle` matching the `\Eris\Generator::shrink` signature.

This PR is a backward compatibility breaking bugfix.

Related test: `\Eris\Generator\BooleanGeneratorTest::testShrinksToFalse`

Fixes issue https://github.com/giorgiosironi/eris/issues/123