### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5 # PHPUnit 4.8
     - php: 5.6 # PHPUnit 5.7
       env: WITH_CS=true
     - php: 7 # PHPUnit 6.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,13 @@ matrix:
     - php: 7.1 # PHPUnit 7.x
     - php: 7.2 # PHPUnit 7.x
     - php: 7.3 # PHPUnit 7.x
-    - php: hhvm
-      env: SKIP_LINT_TEST_CASES=1
-      sudo: required
-      dist: trusty
-      group: edge
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" && "$GITHUB_TOKEN" != "" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
   - composer validate

--- a/examples/LimitToTest.php
+++ b/examples/LimitToTest.php
@@ -12,8 +12,8 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     public function testNumberOfIterationsCanBeConfigured()
     {
         $this->forAll(
-                Generator\int()
-            )
+            Generator\int()
+        )
             ->then(function ($value) {
                 $this->assertInternalType('integer', $value);
             });
@@ -56,8 +56,8 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     public function testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnoredFromAnnotation()
     {
         $this->forAll(
-                Generator\int()
-            )
+            Generator\int()
+        )
             ->then(function ($value) {
                 usleep(100 * 1000);
                 $this->assertTrue(true);

--- a/examples/ShrinkingTest.php
+++ b/examples/ShrinkingTest.php
@@ -9,8 +9,8 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingAString()
     {
         $this->forAll(
-                Generator\string()
-            )
+            Generator\string()
+        )
             ->then(function ($string) {
                 var_dump($string);
                 $this->assertNotContains('B', $string);
@@ -20,8 +20,8 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingRespectsAntecedents()
     {
         $this->forAll(
-                Generator\choose(0, 20)
-            )
+            Generator\choose(0, 20)
+        )
             ->when(function ($number) {
                 return $number > 10;
             })


### PR DESCRIPTION
Changes:

* Travis no longer supports PHP 5.5
* Remove HHVM build as composer no longer supports it
  (see https://github.com/composer/composer/issues/8127#issuecomment-489513083)
* Apply PSR-2 code style changes required by php-cs-fixer
