### PR TITLE
Resolved issue #134

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This test tries to verify that natural numbers from 0 to 1000 are all smaller th
 
 ```php
 <?php
-use Eris\Generator;
+use Eris\Generator\ChooseGenerator;
 
 class ReadmeTest extends \PHPUnit_Framework_TestCase
 {
@@ -42,7 +42,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
     public function testNaturalNumbersMagnitude()
     {
         $this->forAll(
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000)
         )
             ->then(function($number) {
                 $this->assertTrue(

--- a/examples/AlwaysFailsTest.php
+++ b/examples/AlwaysFailsTest.php
@@ -1,5 +1,5 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\ElementsGenerator;
 use Eris\TestTrait;
 
 class AlwaysFailsTest extends \PHPUnit_Framework_TestCase
@@ -9,7 +9,7 @@ class AlwaysFailsTest extends \PHPUnit_Framework_TestCase
     public function testFailsNoMatterWhatIsTheInput()
     {
         $this->forAll(
-            Generator\elements(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
+            ElementsGenerator::elements(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
         )
             ->then(function ($someChar) {
                 $this->fail("This test fails by design. '$someChar' was passed in");

--- a/examples/AssociativeArrayTest.php
+++ b/examples/AssociativeArrayTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\AssociativeArrayGenerator;
+use Eris\Generator\ChooseGenerator;
+use Eris\Generator\ElementsGenerator;
 
 class AssociativeArrayTest extends PHPUnit_Framework_TestCase
 {
@@ -8,9 +10,9 @@ class AssociativeArrayTest extends PHPUnit_Framework_TestCase
     public function testAssociativeArraysGeneratedOnStandardKeys()
     {
         $this->forAll(
-            Generator\associative([
-                'letter' => Generator\elements("A", "B", "C"),
-                'cipher' => Generator\choose(0, 9),
+            AssociativeArrayGenerator::associative([
+                'letter' => ElementsGenerator::elements("A", "B", "C"),
+                'cipher' => ChooseGenerator::choose(0, 9),
             ])
         )
             ->then(function ($array) {

--- a/examples/BindTest.php
+++ b/examples/BindTest.php
@@ -1,5 +1,11 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\BindGenerator;
+use Eris\Generator\ConstantGenerator;
+use Eris\Generator\ElementsGenerator;
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\TupleGenerator;
+use Eris\Generator\VectorGenerator;
 
 class BindTest extends PHPUnit_Framework_TestCase
 {
@@ -8,12 +14,12 @@ class BindTest extends PHPUnit_Framework_TestCase
     public function testCreatingABrandNewGeneratorFromAGeneratedValueSingle()
     {
         $this->forAll(
-            Generator\bind(
-                Generator\vector(4, Generator\nat()),
+            BindGenerator::bind(
+                VectorGenerator::vector(4, IntegerGenerator::nat()),
                 function ($vector) {
-                    return Generator\tuple(
-                        Generator\elements($vector),
-                        Generator\constant($vector)
+                    return TupleGenerator::tuple(
+                        ElementsGenerator::elements($vector),
+                        ConstantGenerator::constant($vector)
                     );
                 }
             )

--- a/examples/BooleanTest.php
+++ b/examples/BooleanTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\BooleanGenerator;
 use Eris\TestTrait;
 
 class BooleanTest extends PHPUnit_Framework_TestCase
@@ -9,7 +10,7 @@ class BooleanTest extends PHPUnit_Framework_TestCase
     public function testBooleanValueIsTrueOrFalse()
     {
         $this->forAll(
-            Generator\bool()
+            BooleanGenerator::bool()
         )
             ->then(function ($boolValue) {
                 $this->assertTrue(

--- a/examples/CharacterTest.php
+++ b/examples/CharacterTest.php
@@ -1,6 +1,6 @@
 <?php
-use Eris\Generator;
 use Eris\Antecedent;
+use Eris\Generator\CharacterGenerator;
 
 class CharacterTest extends PHPUnit_Framework_TestCase
 {
@@ -9,7 +9,7 @@ class CharacterTest extends PHPUnit_Framework_TestCase
     public function testLengthOfAsciiCharactersInPhp()
     {
         $this->forAll(
-            Generator\char(['basic-latin'])
+            CharacterGenerator::char(['basic-latin'])
         )
             ->then(function ($char) {
                 $this->assertLenghtIs1($char);
@@ -19,7 +19,7 @@ class CharacterTest extends PHPUnit_Framework_TestCase
     public function testLengthOfPrintableAsciiCharacters()
     {
         $this->forAll(
-            Generator\char(['basic-latin'])
+            CharacterGenerator::char(['basic-latin'])
         )
             ->when(Antecedent\printableCharacter())
             ->then(function ($char) {
@@ -32,8 +32,8 @@ class CharacterTest extends PHPUnit_Framework_TestCase
         $this
             ->minimumEvaluationRatio(0.1)
             ->forAll(
-                Generator\char(['basic-latin']),
-                Generator\char(['basic-latin'])
+                CharacterGenerator::char(['basic-latin']),
+                CharacterGenerator::char(['basic-latin'])
             )
             ->when(Antecedent\printableCharacters())
             ->then(function ($first, $second) {
@@ -49,8 +49,8 @@ class CharacterTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\char(['basic-latin']),
-                Generator\char(['basic-latin'])
+                CharacterGenerator::char(['basic-latin']),
+                CharacterGenerator::char(['basic-latin'])
             )
             ->when(Antecedent\printableCharacters())
             ->then(function ($first, $second) {

--- a/examples/ChooseTest.php
+++ b/examples/ChooseTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\ChooseGenerator;
 use Eris\TestTrait;
 
 class ChooseTest extends PHPUnit_Framework_TestCase
@@ -9,8 +10,8 @@ class ChooseTest extends PHPUnit_Framework_TestCase
     public function testSumOfTwoIntegersFromBoundedRangesIsCommutative()
     {
         $this->forAll(
-            Generator\choose(-1000, 430),
-            Generator\choose(230, -30000)
+            ChooseGenerator::choose(-1000, 430),
+            ChooseGenerator::choose(230, -30000)
         )
             ->then(function ($first, $second) {
                 $x = $first + $second;

--- a/examples/CollectTest.php
+++ b/examples/CollectTest.php
@@ -1,5 +1,9 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\CharacterGenerator;
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\SequenceGenerator;
+use Eris\Generator\VectorGenerator;
 use Eris\TestTrait;
 use Eris\Listener;
 
@@ -10,7 +14,7 @@ class CollectTest extends PHPUnit_Framework_TestCase
     public function testGeneratedDataCollectionOnScalars()
     {
         $this
-            ->forAll(Generator\neg())
+            ->forAll(IntegerGenerator::neg())
             ->hook(Listener\collectFrequencies())
             ->then(function ($x) {
                 $this->assertTrue($x < $x + 1);
@@ -21,8 +25,8 @@ class CollectTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\vector(2, Generator\int()),
-                Generator\char()
+                VectorGenerator::vector(2, IntegerGenerator::int()),
+                CharacterGenerator::char()
             )
             ->hook(Listener\collectFrequencies())
             ->then(function ($vector) {
@@ -34,7 +38,7 @@ class CollectTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\seq(Generator\nat())
+                SequenceGenerator::seq(IntegerGenerator::nat())
             )
             ->withMaxSize(10)
             ->hook(Listener\collectFrequencies(function ($array) {

--- a/examples/ConstantTest.php
+++ b/examples/ConstantTest.php
@@ -1,6 +1,8 @@
 <?php
 
-use Eris\Generator;
+
+use Eris\Generator\ConstantGenerator;
+use Eris\Generator\IntegerGenerator;
 
 class ConstantTest extends \PHPUnit_Framework_TestCase
 {
@@ -10,8 +12,8 @@ class ConstantTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\nat(),
-                Generator\constant(2)
+                IntegerGenerator::nat(),
+                ConstantGenerator::constant(2)
             )
             ->then(function ($number, $alwaysTwo) {
                 $this->assertTrue(($number * $alwaysTwo % 2) === 0);
@@ -22,7 +24,7 @@ class ConstantTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\nat(),
+                IntegerGenerator::nat(),
                 2
             )
             ->then(function ($number, $alwaysTwo) {

--- a/examples/DateTest.php
+++ b/examples/DateTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\ChooseGenerator;
+use Eris\Generator\DateGenerator;
 
 class DateTest extends PHPUnit_Framework_TestCase
 {
@@ -8,7 +10,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     public function testYearOfADate()
     {
         $this->forAll(
-            Generator\date("2014-01-01T00:00:00", "2014-12-31T23:59:59")
+            DateGenerator::date("2014-01-01T00:00:00", "2014-12-31T23:59:59")
         )
             ->then(function (DateTime $date) {
                 $this->assertEquals(
@@ -21,7 +23,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     public function testDefaultValuesForTheInterval()
     {
         $this->forAll(
-            Generator\date()
+            DateGenerator::date()
         )
             ->then(function (DateTime $date) {
                 $this->assertGreaterThanOrEqual(
@@ -38,9 +40,9 @@ class DateTest extends PHPUnit_Framework_TestCase
     public function testFromDayOfYearFactoryMethodRespectsDistanceBetweenDays()
     {
         $this->forAll(
-            Generator\choose(2000, 2020),
-            Generator\choose(0, 364),
-            Generator\choose(0, 364)
+            ChooseGenerator::choose(2000, 2020),
+            ChooseGenerator::choose(0, 364),
+            ChooseGenerator::choose(0, 364)
         )
         ->then(function ($year, $dayOfYear, $anotherDayOfYear) {
             $day = fromZeroBasedDayOfYear($year, $dayOfYear);

--- a/examples/DifferentElementsTest.php
+++ b/examples/DifferentElementsTest.php
@@ -1,5 +1,9 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\BindGenerator;
+use Eris\Generator\ConstantGenerator;
+use Eris\Generator\ElementsGenerator;
+use Eris\Generator\TupleGenerator;
 use Eris\TestTrait;
 
 class Type
@@ -55,12 +59,12 @@ class DifferentElementsTest extends \PHPUnit_Framework_TestCase
         };
 
         $this
-            ->forAll(Generator\bind(
+            ->forAll(BindGenerator::bind(
                 call_user_func_array('Eris\Generator\elements', $allTypes),
                 function ($first) use ($allTypes, $remove) {
-                    return Generator\tuple(
-                        Generator\constant($first),
-                        Generator\elements($remove($allTypes, $first))
+                    return TupleGenerator::tuple(
+                        ConstantGenerator::constant($first),
+                        ElementsGenerator::elements($remove($allTypes, $first))
                     );
                 }
             ))

--- a/examples/DisableShrinkingTest.php
+++ b/examples/DisableShrinkingTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
 use Eris\TestTrait;
 
 class DisableShrinkingTest extends \PHPUnit_Framework_TestCase
@@ -14,7 +15,7 @@ class DisableShrinkingTest extends \PHPUnit_Framework_TestCase
         $this->calls = 0;
         $this
             ->forAll(
-                Generator\nat()
+                IntegerGenerator::nat()
             )
             ->disableShrinking()
             ->then(function ($number) {

--- a/examples/ElementsTest.php
+++ b/examples/ElementsTest.php
@@ -1,5 +1,8 @@
 <?php
-use Eris\Generator;
+
+
+use Eris\Generator\ElementsGenerator;
+use Eris\Generator\VectorGenerator;
 
 class ElementsTest extends \PHPUnit_Framework_TestCase
 {
@@ -8,7 +11,7 @@ class ElementsTest extends \PHPUnit_Framework_TestCase
     public function testElementsOnlyProducesElementsFromTheGivenArguments()
     {
         $this->forAll(
-            Generator\elements(1, 2, 3)
+            ElementsGenerator::elements(1, 2, 3)
         )
             ->then(function ($number) {
                 $this->assertContains(
@@ -26,7 +29,7 @@ class ElementsTest extends \PHPUnit_Framework_TestCase
     public function testElementsOnlyProducesElementsFromTheGivenArrayDomain()
     {
         $this->forAll(
-            Generator\elements([1, 2, 3])
+            ElementsGenerator::elements([1, 2, 3])
         )
             ->then(function ($number) {
                 $this->assertContains(
@@ -40,9 +43,9 @@ class ElementsTest extends \PHPUnit_Framework_TestCase
     public function testVectorOfElementsGenerators()
     {
         $this->forAll(
-            Generator\vector(
+            VectorGenerator::vector(
                 4,
-                Generator\elements([2, 4, 6, 8, 10, 12])
+                ElementsGenerator::elements([2, 4, 6, 8, 10, 12])
             )
         )
             ->then(function ($vector) {

--- a/examples/ErrorTest.php
+++ b/examples/ErrorTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+
+
+use Eris\Generator\StringGenerator;
 
 class ErrorTest extends \PHPUnit_Framework_TestCase
 {
@@ -8,7 +10,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     public function testGenericExceptionsDoNotShrinkButStillShowTheInput()
     {
         $this->forAll(
-            Generator\string()
+            StringGenerator::string()
         )
             ->then(function ($string) {
                 throw new RuntimeException("Something like a missing array index happened.");

--- a/examples/FloatTest.php
+++ b/examples/FloatTest.php
@@ -1,5 +1,5 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\FloatGenerator;
 
 class FloatTest extends \PHPUnit_Framework_TestCase
 {
@@ -7,7 +7,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
 
     public function testAPropertyHoldingForAllNumbers()
     {
-        $this->forAll(Generator\float())
+        $this->forAll(FloatGenerator::float())
             ->then(function ($number) {
                 $this->assertEquals(
                     0.0,
@@ -18,7 +18,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
 
     public function testAPropertyHoldingOnlyForPositiveNumbers()
     {
-        $this->forAll(Generator\float())
+        $this->forAll(FloatGenerator::float())
             ->then(function ($number) {
                 $this->assertTrue(
                     $number >= 0,

--- a/examples/FrequencyTest.php
+++ b/examples/FrequencyTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\ChooseGenerator;
+use Eris\Generator\FrequencyGenerator;
 
 class FrequencyTest extends \PHPUnit_Framework_TestCase
 {
@@ -9,7 +10,7 @@ class FrequencyTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\frequency(
+                FrequencyGenerator::frequency(
                     [8, false],
                     [4, 0],
                     [4, '']
@@ -24,10 +25,10 @@ class FrequencyTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\frequency(
-                    [8, Generator\choose(1, 100)],
-                    [4, Generator\choose(100, 200)],
-                    [4, Generator\choose(200, 300)]
+                FrequencyGenerator::frequency(
+                    [8, ChooseGenerator::choose(1, 100)],
+                    [4, ChooseGenerator::choose(100, 200)],
+                    [4, ChooseGenerator::choose(200, 300)]
                 )
             )
             ->then(function ($element) {

--- a/examples/GeneratorSamplesTest.php
+++ b/examples/GeneratorSamplesTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
 use Eris\TestTrait;
 
 class GeneratorSamplesTest extends PHPUnit_Framework_TestCase
@@ -10,9 +11,9 @@ class GeneratorSamplesTest extends PHPUnit_Framework_TestCase
     {
         $generators = [
             //"Gen\\int" => Generator\int(),
-            "Gen\\neg" => Generator\neg(),
+            "Gen\\neg" => IntegerGenerator::neg(),
             //"Gen\\nat" => Generator\nat(),
-            "Gen\\pos" => Generator\pos(),
+            "Gen\\pos" => IntegerGenerator::pos(),
             /*
             "Gen\\float" => Generator\float(),
             "Gen\\choose(30, 9000) - no size used" => Generator\choose(30, 9000),

--- a/examples/IntegerTest.php
+++ b/examples/IntegerTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
 use Eris\TestTrait;
 
 class IntegerTest extends PHPUnit_Framework_TestCase
@@ -9,8 +10,8 @@ class IntegerTest extends PHPUnit_Framework_TestCase
     public function testSumIsCommutative()
     {
         $this->forAll(
-            Generator\int(),
-            Generator\int()
+            IntegerGenerator::int(),
+            IntegerGenerator::int()
         )
             ->then(function ($first, $second) {
                 $x = $first + $second;
@@ -26,9 +27,9 @@ class IntegerTest extends PHPUnit_Framework_TestCase
     public function testSumIsAssociative()
     {
         $this->forAll(
-            Generator\int(),
-            Generator\neg(),
-            Generator\pos()
+            IntegerGenerator::int(),
+            IntegerGenerator::neg(),
+            IntegerGenerator::pos()
         )
             ->then(function ($first, $second, $third) {
                 $x = $first + ($second + $third);
@@ -44,7 +45,7 @@ class IntegerTest extends PHPUnit_Framework_TestCase
     public function testByteData()
     {
         $this->forAll(
-            Generator\byte()
+            IntegerGenerator::byte()
         )
             ->then(function ($byte) {
                 $this->assertTrue(

--- a/examples/LimitToTest.php
+++ b/examples/LimitToTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
 use Eris\TestTrait;
 
 class LimitToTest extends PHPUnit_Framework_TestCase
@@ -12,7 +13,7 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     public function testNumberOfIterationsCanBeConfigured()
     {
         $this->forAll(
-            Generator\int()
+            IntegerGenerator::int()
         )
             ->then(function ($value) {
                 $this->assertInternalType('integer', $value);
@@ -26,7 +27,7 @@ class LimitToTest extends PHPUnit_Framework_TestCase
         $this->minimum(10)
              ->limitTo(new DateInterval("PT2S"))
              ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->then(function($value) {
                 usleep(100 * 1000);
@@ -41,7 +42,7 @@ class LimitToTest extends PHPUnit_Framework_TestCase
             ->minimumEvaluationRatio(0)
             ->limitTo(new DateInterval('PT2S'))
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->then(function ($value) {
                 usleep(100 * 1000);
@@ -56,7 +57,7 @@ class LimitToTest extends PHPUnit_Framework_TestCase
     public function testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnoredFromAnnotation()
     {
         $this->forAll(
-            Generator\int()
+            IntegerGenerator::int()
         )
             ->then(function ($value) {
                 usleep(100 * 1000);

--- a/examples/LogFileTest.php
+++ b/examples/LogFileTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
 use Eris\TestTrait;
 use Eris\Listener;
 
@@ -11,7 +12,7 @@ class LogFileTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->hook(Listener\log(sys_get_temp_dir().'/eris-log-file-test.log'))
             ->then(function ($number) {
@@ -23,7 +24,7 @@ class LogFileTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->hook(Listener\log(sys_get_temp_dir().'/eris-log-file-shrinking.log'))
             ->then(function ($number) {

--- a/examples/MapTest.php
+++ b/examples/MapTest.php
@@ -1,5 +1,9 @@
 <?php
-use Eris\Generator;
+
+
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\MapGenerator;
+use Eris\Generator\VectorGenerator;
 
 class MapTest extends PHPUnit_Framework_TestCase
 {
@@ -8,13 +12,13 @@ class MapTest extends PHPUnit_Framework_TestCase
     public function testApplyingAFunctionToGeneratedValues()
     {
         $this->forAll(
-            Generator\vector(
+            VectorGenerator::vector(
                 3,
-                Generator\map(
+                MapGenerator::map(
                     function ($n) {
                         return $n * 2;
                     },
-                    Generator\nat()
+                    IntegerGenerator::nat()
                 )
             )
         )
@@ -31,11 +35,11 @@ class MapTest extends PHPUnit_Framework_TestCase
     public function testShrinkingJustMappedValues()
     {
         $this->forAll(
-            Generator\map(
+            MapGenerator::map(
                 function ($n) {
                     return $n * 2;
                 },
-                Generator\nat()
+                IntegerGenerator::nat()
             )
         )
             ->then(function ($evenNumber) {
@@ -50,13 +54,13 @@ class MapTest extends PHPUnit_Framework_TestCase
     public function testShrinkingMappedValuesInsideOtherGenerators()
     {
         $this->forAll(
-            Generator\vector(
+            VectorGenerator::vector(
                 3,
-                Generator\map(
+                MapGenerator::map(
                     function ($n) {
                         return $n * 2;
                     },
-                    Generator\nat()
+                    IntegerGenerator::nat()
                 )
             )
         )

--- a/examples/MinimumEvaluationsTest.php
+++ b/examples/MinimumEvaluationsTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+
+
+use Eris\Generator\ChooseGenerator;
 
 class MinimumEvaluationsTest extends PHPUnit_Framework_TestCase
 {
@@ -9,7 +11,7 @@ class MinimumEvaluationsTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\choose(0, 100)
+                ChooseGenerator::choose(0, 100)
             )
             ->when(function ($n) {
                 return $n > 90;
@@ -24,7 +26,7 @@ class MinimumEvaluationsTest extends PHPUnit_Framework_TestCase
         $this
             ->minimumEvaluationRatio(0.01)
             ->forAll(
-                Generator\choose(0, 100)
+                ChooseGenerator::choose(0, 100)
             )
             ->when(function ($n) {
                 return $n > 90;
@@ -41,7 +43,7 @@ class MinimumEvaluationsTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\choose(0, 100)
+                ChooseGenerator::choose(0, 100)
             )
             ->when(function ($n) {
                 return $n > 90;

--- a/examples/NamesTest.php
+++ b/examples/NamesTest.php
@@ -1,5 +1,5 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\NamesGenerator;
 
 class NamesTest extends PHPUnit_Framework_TestCase
 {
@@ -8,7 +8,7 @@ class NamesTest extends PHPUnit_Framework_TestCase
     public function testGeneratingNames()
     {
         $this->forAll(
-            Generator\names()
+            NamesGenerator::names()
         )->then(function ($name) {
             $this->assertInternalType('string', $name);
             var_dump($name);
@@ -17,7 +17,7 @@ class NamesTest extends PHPUnit_Framework_TestCase
 
     public function testSamplingShrinkingOfNames()
     {
-        $generator = Generator\NamesGenerator::defaultDataSet();
+        $generator = NamesGenerator::defaultDataSet();
         $sample = $this->sampleShrink($generator);
         $this->assertInternalType('array', $sample->collected());
         var_dump($sample->collected());

--- a/examples/OneOfTest.php
+++ b/examples/OneOfTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\OneOfGenerator;
 
 class OneOfTest extends \PHPUnit_Framework_TestCase
 {
@@ -9,9 +10,9 @@ class OneOfTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\oneOf(
-                    Generator\pos(),
-                    Generator\neg()
+                OneOfGenerator::oneOf(
+                    IntegerGenerator::pos(),
+                    IntegerGenerator::neg()
                 )
             )
             ->then(function ($number) {

--- a/examples/RandConfigurationTest.php
+++ b/examples/RandConfigurationTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
 use Eris\Random;
 use Eris\TestTrait;
 
@@ -12,7 +13,7 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
         $this
             ->withRand('rand')
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->withMaxSize(1000 * 1000* 1000)
             ->then($this->isInteger());
@@ -25,7 +26,7 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->withMaxSize(1000 * 1000* 1000)
             ->then($this->isInteger());
@@ -36,7 +37,7 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
         $this
             ->withRand('mt_rand')
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->then($this->isInteger());
     }
@@ -49,7 +50,7 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->then($this->isInteger());
     }
@@ -63,7 +64,7 @@ class RandConfigurationTest extends PHPUnit_Framework_TestCase
         $this
             ->withRand(Random\purePhpMtRand())
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->then($this->isInteger());
     }

--- a/examples/ReadmeTest.php
+++ b/examples/ReadmeTest.php
@@ -1,5 +1,5 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\ChooseGenerator;
 
 class ReadmeTest extends \PHPUnit_Framework_TestCase
 {
@@ -8,7 +8,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
     public function testNaturalNumbersMagnitude()
     {
         $this->forAll(
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000)
         )
             ->then(function ($number) {
                 $this->assertTrue(

--- a/examples/RegexTest.php
+++ b/examples/RegexTest.php
@@ -1,5 +1,5 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\RegexGenerator;
 
 class RegexTest extends \PHPUnit_Framework_TestCase
 {
@@ -11,7 +11,7 @@ class RegexTest extends \PHPUnit_Framework_TestCase
     public function testStringsMatchingAParticularRegex()
     {
         $this->forAll(
-            Generator\regex("[a-z]{10}")
+            RegexGenerator::regex("[a-z]{10}")
         )
             ->then(function ($string) {
                 $this->assertEquals(10, strlen($string));

--- a/examples/SequenceTest.php
+++ b/examples/SequenceTest.php
@@ -1,5 +1,8 @@
 <?php
-use Eris\Generator;
+
+
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\SequenceGenerator;
 
 class SequenceTest extends PHPUnit_Framework_TestCase
 {
@@ -9,7 +12,7 @@ class SequenceTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\seq(Generator\nat())
+                SequenceGenerator::seq(IntegerGenerator::nat())
             )
             ->then(function ($array) {
                 $this->assertEquals(count($array), count(array_reverse($array)));
@@ -20,7 +23,7 @@ class SequenceTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\seq(Generator\nat())
+                SequenceGenerator::seq(IntegerGenerator::nat())
             )
             ->then(function ($array) {
                 $this->assertEquals($array, array_reverse(array_reverse($array)));
@@ -31,7 +34,7 @@ class SequenceTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\seq(Generator\nat())
+                SequenceGenerator::seq(IntegerGenerator::nat())
             )
             ->then(function ($array) {
                 sort($array);

--- a/examples/SetTest.php
+++ b/examples/SetTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\SetGenerator;
 use Eris\TestTrait;
 
 class SetTest extends PHPUnit_Framework_TestCase
@@ -9,7 +11,7 @@ class SetTest extends PHPUnit_Framework_TestCase
     public function testSetsOfAnotherGeneratorsDomain()
     {
         $this->forAll(
-            Generator\set(Generator\nat())
+            SetGenerator::set(IntegerGenerator::nat())
         )
             ->then(function ($set) {
                 $this->assertInternalType('array', $set);

--- a/examples/ShrinkingTest.php
+++ b/examples/ShrinkingTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\ChooseGenerator;
+use Eris\Generator\StringGenerator;
 use Eris\TestTrait;
 
 class ShrinkingTest extends \PHPUnit_Framework_TestCase
@@ -9,7 +11,7 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingAString()
     {
         $this->forAll(
-            Generator\string()
+            StringGenerator::string()
         )
             ->then(function ($string) {
                 var_dump($string);
@@ -20,7 +22,7 @@ class ShrinkingTest extends \PHPUnit_Framework_TestCase
     public function testShrinkingRespectsAntecedents()
     {
         $this->forAll(
-            Generator\choose(0, 20)
+            ChooseGenerator::choose(0, 20)
         )
             ->when(function ($number) {
                 return $number > 10;

--- a/examples/ShrinkingTimeLimitTest.php
+++ b/examples/ShrinkingTimeLimitTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\StringGenerator;
 
 function very_slow_concatenation($first, $second)
 {
@@ -19,8 +20,8 @@ class ShrinkingTimeLimitTest extends PHPUnit_Framework_TestCase
         $this
             ->shrinkingTimeLimit(2)
             ->forAll(
-                Generator\string(),
-                Generator\string()
+                StringGenerator::string(),
+                StringGenerator::string()
             )
             ->then(function ($first, $second) {
                 $result = very_slow_concatenation($first, $second);
@@ -39,8 +40,8 @@ class ShrinkingTimeLimitTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\string(),
-                Generator\string()
+                StringGenerator::string(),
+                StringGenerator::string()
             )
             ->then(function ($first, $second) {
                 $result = very_slow_concatenation($first, $second);

--- a/examples/SizeTest.php
+++ b/examples/SizeTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\IntegerGenerator;
 use Eris\TestTrait;
 
 class SizeTest extends PHPUnit_Framework_TestCase
@@ -14,7 +15,7 @@ class SizeTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\int()
+                IntegerGenerator::int()
             )
             ->withMaxSize(1000 * 1000)
             ->then(function ($number) {

--- a/examples/SortTest.php
+++ b/examples/SortTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\SequenceGenerator;
 
 class SortTest extends PHPUnit_Framework_TestCase
 {
@@ -9,7 +10,7 @@ class SortTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\seq(Generator\nat())
+                SequenceGenerator::seq(IntegerGenerator::nat())
             )
             ->then(function ($array) {
                 sort($array);

--- a/examples/StringTest.php
+++ b/examples/StringTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+
+use Eris\Generator\StringGenerator;
 use Eris\Listener;
 
 function string_concatenation($first, $second)
@@ -18,7 +19,7 @@ class StringTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\string()
+                StringGenerator::string()
             )
             ->then(function ($string) {
                 $this->assertEquals(
@@ -33,8 +34,8 @@ class StringTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\string(),
-                Generator\string()
+                StringGenerator::string(),
+                StringGenerator::string()
             )
             ->hook(Listener\log(sys_get_temp_dir().'/eris-string-shrinking.log'))
             ->then(function ($first, $second) {

--- a/examples/SubsetTest.php
+++ b/examples/SubsetTest.php
@@ -1,5 +1,5 @@
 <?php
-use Eris\Generator;
+
 use Eris\TestTrait;
 
 class SubsetTest extends PHPUnit_Framework_TestCase
@@ -9,7 +9,7 @@ class SubsetTest extends PHPUnit_Framework_TestCase
     public function testSubsetsOfASet()
     {
         $this->forAll(
-            Generator\subset([
+            SubsetGenerator::subset([
                 2, 4, 6, 8, 10
             ])
         )

--- a/examples/SubsetTest.php
+++ b/examples/SubsetTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Eris\Generator\SubsetGenerator;
 use Eris\TestTrait;
 
 class SubsetTest extends PHPUnit_Framework_TestCase

--- a/examples/SuchThatTest.php
+++ b/examples/SuchThatTest.php
@@ -1,5 +1,9 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\ChooseGenerator;
+use Eris\Generator\OneOfGenerator;
+use Eris\Generator\StringGenerator;
+use Eris\Generator\SuchThatGenerator;
+use Eris\Generator\VectorGenerator;
 use Eris\Listener;
 
 class SuchThatTest extends \PHPUnit_Framework_TestCase
@@ -10,13 +14,13 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\vector(
+                VectorGenerator::vector(
                     5,
-                    Generator\suchThat(
+                    SuchThatGenerator::suchThat(
                         function ($n) {
                             return $n > 42;
                         },
-                        Generator\choose(0, 1000)
+                        ChooseGenerator::choose(0, 1000)
                     )
                 )
             )
@@ -27,13 +31,13 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\vector(
+                VectorGenerator::vector(
                     5,
-                    Generator\filter(
+                    SuchThatGenerator::filter(
                         function ($n) {
                             return $n > 42;
                         },
-                        Generator\choose(0, 1000)
+                        ChooseGenerator::choose(0, 1000)
                     )
                 )
             )
@@ -44,13 +48,13 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\vector(
+                VectorGenerator::vector(
                     5,
-                    Generator\suchThat(
+                    SuchThatGenerator::suchThat(
                         $this->isType('integer'),
-                        Generator\oneOf(
-                            Generator\choose(0, 1000),
-                            Generator\string()
+                        OneOfGenerator::oneOf(
+                            ChooseGenerator::choose(0, 1000),
+                            StringGenerator::string()
                         )
                     )
                 )
@@ -64,11 +68,11 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\suchThat(
+                SuchThatGenerator::suchThat(
                     function ($n) {
                         return $n > 42;
                     },
-                    Generator\choose(0, 1000)
+                    ChooseGenerator::choose(0, 1000)
                 )
             )
             ->then($this->numberIsBiggerThan(100));
@@ -78,11 +82,11 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\suchThat(
+                SuchThatGenerator::suchThat(
                     function ($n) {
                         return $n <> 42;
                     },
-                    Generator\choose(0, 1000)
+                    ChooseGenerator::choose(0, 1000)
                 )
             )
             ->then($this->numberIsBiggerThan(100));
@@ -92,11 +96,11 @@ class SuchThatTest extends \PHPUnit_Framework_TestCase
     {
         $this
             ->forAll(
-                Generator\suchThat(
+                SuchThatGenerator::suchThat(
                     function (array $ints) {
                         return count($ints) > 0;
                     },
-                    Generator\seq(Generator\int())
+                    SequenceGenerator::seq(IntegerGenerator::int())
                 )
             )
             ->then(function (array $ints) use (&$i) {

--- a/examples/SuchThatTest.php
+++ b/examples/SuchThatTest.php
@@ -1,6 +1,8 @@
 <?php
 use Eris\Generator\ChooseGenerator;
+use Eris\Generator\IntegerGenerator;
 use Eris\Generator\OneOfGenerator;
+use Eris\Generator\SequenceGenerator;
 use Eris\Generator\StringGenerator;
 use Eris\Generator\SuchThatGenerator;
 use Eris\Generator\VectorGenerator;

--- a/examples/SumTest.php
+++ b/examples/SumTest.php
@@ -1,5 +1,5 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\IntegerGenerator;
 
 function my_sum($first, $second)
 {
@@ -16,7 +16,7 @@ class SumTest extends PHPUnit_Framework_TestCase
     public function testRightIdentityElement()
     {
         $this->forAll(
-            Generator\nat(1000)
+            IntegerGenerator::nat(1000)
         )
             ->then(function ($number) {
                 $this->assertEquals(
@@ -30,7 +30,7 @@ class SumTest extends PHPUnit_Framework_TestCase
     public function testLeftIdentityElement()
     {
         $this->forAll(
-            Generator\nat(1000)
+            IntegerGenerator::nat(1000)
         )
             ->then(function ($number) {
                 $this->assertEquals(
@@ -44,8 +44,8 @@ class SumTest extends PHPUnit_Framework_TestCase
     public function testEqualToReferencePhpImplementation()
     {
         $this->forAll(
-            Generator\nat(1000),
-            Generator\nat(1000)
+            IntegerGenerator::nat(1000),
+            IntegerGenerator::nat(1000)
         )
             ->then(function ($first, $second) {
                 $this->assertEquals(
@@ -59,8 +59,8 @@ class SumTest extends PHPUnit_Framework_TestCase
     public function testPropertyNeverSatisfied()
     {
         $this->forAll(
-            Generator\nat(1000),
-            Generator\nat(1000)
+            IntegerGenerator::nat(1000),
+            IntegerGenerator::nat(1000)
         )
             ->then(function ($first, $second) {
                 $this->assertEquals(

--- a/examples/TupleTest.php
+++ b/examples/TupleTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\ChooseGenerator;
+use Eris\Generator\ElementsGenerator;
+use Eris\Generator\TupleGenerator;
 
 class TupleTest extends PHPUnit_Framework_TestCase
 {
@@ -8,9 +10,9 @@ class TupleTest extends PHPUnit_Framework_TestCase
     public function testConcatenationMaintainsLength()
     {
         $this->forAll(
-            Generator\tuple(
-                Generator\elements("A", "B", "C"),
-                Generator\choose(0, 9)
+            TupleGenerator::tuple(
+                ElementsGenerator::elements("A", "B", "C"),
+                ChooseGenerator::choose(0, 9)
             )
         )
             ->then(function ($tuple) {

--- a/examples/VectorTest.php
+++ b/examples/VectorTest.php
@@ -1,5 +1,6 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\VectorGenerator;
 
 class VectorTest extends PHPUnit_Framework_TestCase
 {
@@ -8,8 +9,8 @@ class VectorTest extends PHPUnit_Framework_TestCase
     public function testConcatenationMaintainsLength()
     {
         $this->forAll(
-            Generator\vector(10, Generator\nat(1000)),
-            Generator\vector(10, Generator\nat(1000))
+            VectorGenerator::vector(10, IntegerGenerator::nat(1000)),
+            VectorGenerator::vector(10, IntegerGenerator::nat(1000))
         )
             ->then(function ($first, $second) {
                 $concatenated = array_merge($first, $second);

--- a/examples/WhenTest.php
+++ b/examples/WhenTest.php
@@ -1,5 +1,7 @@
 <?php
-use Eris\Generator;
+use Eris\Generator\ChooseGenerator;
+use Eris\Generator\ElementsGenerator;
+use Eris\Generator\SequenceGenerator;
 
 class WhenTest extends \PHPUnit_Framework_TestCase
 {
@@ -8,7 +10,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testWhenWithAnAnonymousFunctionWithGherkinSyntax()
     {
         $this->forAll(
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000)
         )
             ->when(function ($n) {
                 return $n > 42;
@@ -24,8 +26,8 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testWhenWithAnAnonymousFunctionForMultipleArguments()
     {
         $this->forAll(
-            Generator\choose(0, 1000),
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000),
+            ChooseGenerator::choose(0, 1000)
         )
             ->when(function ($first, $second) {
                 return $first > 42 && $second > 23;
@@ -41,7 +43,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testWhenWithOnePHPUnitConstraint()
     {
         $this->forAll(
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000)
         )
             ->when($this->greaterThan(42))
             ->then(function ($number) {
@@ -55,8 +57,8 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testWhenWithMultiplePHPUnitConstraints()
     {
         $this->forAll(
-            Generator\choose(0, 1000),
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000),
+            ChooseGenerator::choose(0, 1000)
         )
             ->when($this->greaterThan(42), $this->greaterThan(23))
             ->then(function ($first, $second) {
@@ -70,7 +72,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testMultipleWhenClausesWithGherkinSyntax()
     {
         $this->forAll(
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000)
         )
             ->when($this->greaterThan(42))
             ->and($this->lessThan(900))
@@ -85,7 +87,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testWhenWhichSkipsTooManyValues()
     {
         $this->forAll(
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000)
         )
             ->when($this->greaterThan(800))
             ->then(function ($number) {
@@ -103,7 +105,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testWhenFailingWillNaturallyHaveALowEvaluationRatioSoWeDontWantThatErrorToObscureTheTrueOne()
     {
         $this->forAll(
-            Generator\choose(0, 1000)
+            ChooseGenerator::choose(0, 1000)
         )
             ->when($this->greaterThan(100))
             ->then(function ($number) {
@@ -117,7 +119,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     public function testSizeIncreasesEvenIfEvaluationsAreSkippedDueToAntecedentsNotBeingSatisfied()
     {
         $this->forAll(
-            Generator\seq(Generator\elements(1, 2, 3))
+            SequenceGenerator::seq(ElementsGenerator::elements(1, 2, 3))
         )
             ->when(function ($seq) {
                 return count($seq) > 0;

--- a/examples/generating_integers.php
+++ b/examples/generating_integers.php
@@ -5,7 +5,7 @@ require __DIR__.'/../vendor/autoload.php';
 
 $eris = new Eris\Facade();
 $eris
-    ->forAll(Generator\int())
+    ->forAll(Generator\IntegerGenerator::int())
     ->then(function ($integer) {
         echo var_export($integer, true) . PHP_EOL;
     });

--- a/src/Generator/AssociativeArrayGenerator.php
+++ b/src/Generator/AssociativeArrayGenerator.php
@@ -5,11 +5,12 @@ use Eris\Generator;
 use Eris\Random\RandomRange;
 
 /**
+ * @param array<Generator> $generators
  * @return AssociativeArrayGenerator
  */
 function associative(array $generators)
 {
-    return new AssociativeArrayGenerator($generators);
+    return AssociativeArrayGenerator::associative($generators);
 }
 
 class AssociativeArrayGenerator implements Generator
@@ -50,5 +51,14 @@ class AssociativeArrayGenerator implements Generator
             },
             'associative'
         );
+    }
+
+    /**
+     * @param array<Generator> $generators
+     * @return AssociativeArrayGenerator
+     */
+    public static function associative(array $generators)
+    {
+        return new self($generators);
     }
 }

--- a/src/Generator/BindGenerator.php
+++ b/src/Generator/BindGenerator.php
@@ -4,12 +4,14 @@ namespace Eris\Generator;
 use Eris\Generator;
 use Eris\Random\RandomRange;
 
+/**
+ * @param Generator $innerGenerator
+ * @param callable $outerGeneratorFactory
+ * @return BindGenerator
+ */
 function bind(Generator $innerGenerator, callable $outerGeneratorFactory)
 {
-    return new BindGenerator(
-        $innerGenerator,
-        $outerGeneratorFactory
-    );
+    return BindGenerator::bind($innerGenerator, $outerGeneratorFactory);
 }
 
 class BindGenerator implements Generator
@@ -55,6 +57,19 @@ class BindGenerator implements Generator
                 $innerGeneratorValue,
             ],
             'bind'
+        );
+    }
+
+    /**
+     * @param Generator $innerGenerator
+     * @param callable $outerGeneratorFactory
+     * @return BindGenerator
+     */
+    public static function bind(Generator $innerGenerator, callable $outerGeneratorFactory)
+    {
+        return new self(
+            $innerGenerator,
+            $outerGeneratorFactory
         );
     }
 }

--- a/src/Generator/BooleanGenerator.php
+++ b/src/Generator/BooleanGenerator.php
@@ -4,9 +4,12 @@ namespace Eris\Generator;
 use Eris\Generator;
 use Eris\Random\RandomRange;
 
+/**
+ * @return BooleanGenerator
+ */
 function bool()
 {
-    return new BooleanGenerator();
+    return BooleanGenerator::bool();
 }
 
 class BooleanGenerator implements Generator
@@ -22,5 +25,13 @@ class BooleanGenerator implements Generator
     public function shrink(GeneratedValue $element)
     {
         return GeneratedValueSingle::fromJustValue(false);
+    }
+
+    /**
+     * @return BooleanGenerator
+     */
+    public static function bool()
+    {
+        return new self();
     }
 }

--- a/src/Generator/CharacterGenerator.php
+++ b/src/Generator/CharacterGenerator.php
@@ -60,4 +60,27 @@ class CharacterGenerator implements Generator
         $shrinkedValue = chr($this->shrinkingProgression->next(ord($element->unbox())));
         return GeneratedValueSingle::fromJustValue($shrinkedValue, 'character');
     }
+
+    /**
+     * Generates character in the ASCII 0-127 range.
+     *
+     * @param array $characterSets  Only supported charset: "basic-latin"
+     * @param string $encoding  Only supported encoding: "utf-8"
+     * @return Generator\CharacterGenerator
+     */
+    public static function char(array $characterSets = ['basic-latin'], $encoding = 'utf-8')
+    {
+        return self::ascii();
+    }
+
+    /**
+     * Generates character in the ASCII 32-127 range, excluding non-printable ones
+     * or modifiers such as CR, LF and Tab.
+     *
+     * @return Generator\CharacterGenerator
+     */
+    public static function charPrintableAscii()
+    {
+        return self::printableAscii();
+    }
 }

--- a/src/Generator/ChooseGenerator.php
+++ b/src/Generator/ChooseGenerator.php
@@ -15,13 +15,13 @@ if (!defined('ERIS_PHP_INT_MIN')) {
  * The order of the parameters does not care since they are re-ordered by the
  * generator itself.
  *
- * @param $x int One of the 2 boundaries of the range
- * @param $y int The other boundary of the range
+ * @param $lowerLimit int One of the 2 boundaries of the range
+ * @param $upperLimit int The other boundary of the range
  * @return Generator\ChooseGenerator
  */
 function choose($lowerLimit, $upperLimit)
 {
-    return new ChooseGenerator($lowerLimit, $upperLimit);
+    return ChooseGenerator::choose($lowerLimit, $upperLimit);
 }
 
 class ChooseGenerator implements Generator
@@ -71,5 +71,20 @@ class ChooseGenerator implements Generator
                 'be Integers between ' . ERIS_PHP_INT_MIN . ' and ' . PHP_INT_MAX
             );
         }
+    }
+
+    /**
+     * Generates a number in the range from the lower bound to the upper bound,
+     * inclusive. The result shrinks towards smaller absolute values.
+     * The order of the parameters does not care since they are re-ordered by the
+     * generator itself.
+     *
+     * @param $lowerLimit int One of the 2 boundaries of the range
+     * @param $upperLimit int The other boundary of the range
+     * @return Generator\ChooseGenerator
+     */
+    public static function choose($lowerLimit, $upperLimit)
+    {
+        return new self($lowerLimit, $upperLimit);
     }
 }

--- a/src/Generator/ConstantGenerator.php
+++ b/src/Generator/ConstantGenerator.php
@@ -17,7 +17,7 @@ class ConstantGenerator implements Generator
 {
     private $value;
 
-    private static function box($value)
+    public static function box($value)
     {
         return new self($value);
     }

--- a/src/Generator/ConstantGenerator.php
+++ b/src/Generator/ConstantGenerator.php
@@ -10,14 +10,14 @@ use Eris\Random\RandomRange;
  */
 function constant($value)
 {
-    return ConstantGenerator::box($value);
+    return ConstantGenerator::constant($value);
 }
 
 class ConstantGenerator implements Generator
 {
     private $value;
 
-    public static function box($value)
+    private static function box($value)
     {
         return new self($value);
     }
@@ -35,5 +35,14 @@ class ConstantGenerator implements Generator
     public function shrink(GeneratedValue $element)
     {
         return GeneratedValueSingle::fromJustValue($this->value, 'constant');
+    }
+
+    /**
+     * @param mixed $value  the only value to generate
+     * @return ConstantGenerator
+     */
+    public static function constant($value)
+    {
+        return self::box($value);
     }
 }

--- a/src/Generator/DateGenerator.php
+++ b/src/Generator/DateGenerator.php
@@ -5,28 +5,15 @@ use Eris\Generator;
 use Eris\Random\RandomRange;
 use DateTime;
 
+/**
+ * @param DateTime|null $lowerLimit
+ * @param DateTime|null $upperLimit
+ * @return DateGenerator
+ * @throws \Exception
+ */
 function date($lowerLimit = null, $upperLimit = null)
 {
-    $box = function ($date) {
-        if ($date === null) {
-            return $date;
-        }
-        if ($date instanceof DateTime) {
-            return $date;
-        }
-        return new DateTime($date);
-    };
-    $withDefault = function ($value, $default) {
-        if ($value !== null) {
-            return $value;
-        }
-        return $default;
-    };
-    return new DateGenerator(
-        $withDefault($box($lowerLimit), new DateTime("@0")),
-        // uses a maximum which is conservative
-        $withDefault($box($upperLimit), new DateTime("@" . (pow(2, 31) - 1)))
-    );
+    return DateGenerator::date($lowerLimit, $upperLimit);
 }
 
 class DateGenerator implements Generator
@@ -71,5 +58,35 @@ class DateGenerator implements Generator
         $element = new DateTime();
         $element->setTimestamp($chosenTimestamp);
         return $element;
+    }
+
+    /**
+     * @param DateTime|null $lowerLimit
+     * @param DateTime|null $upperLimit
+     * @return DateGenerator
+     * @throws \Exception
+     */
+    public static function date($lowerLimit = null, $upperLimit = null)
+    {
+        $box = static function ($date) {
+            if ($date === null) {
+                return $date;
+            }
+            if ($date instanceof DateTime) {
+                return $date;
+            }
+            return new DateTime($date);
+        };
+        $withDefault = static function ($value, $default) {
+            if ($value !== null) {
+                return $value;
+            }
+            return $default;
+        };
+        return new self(
+            $withDefault($box($lowerLimit), new DateTime("@0")),
+            // uses a maximum which is conservative
+            $withDefault($box($upperLimit), new DateTime("@" . (pow(2, 31) - 1)))
+        );
     }
 }

--- a/src/Generator/ElementsGenerator.php
+++ b/src/Generator/ElementsGenerator.php
@@ -16,7 +16,7 @@ class ElementsGenerator implements Generator
 {
     private $domain;
 
-    private static function fromArray(array $domain)
+    public static function fromArray(array $domain)
     {
         return new self($domain);
     }

--- a/src/Generator/ElementsGenerator.php
+++ b/src/Generator/ElementsGenerator.php
@@ -4,22 +4,19 @@ namespace Eris\Generator;
 use Eris\Generator;
 use Eris\Random\RandomRange;
 
+/**
+ * @return ElementsGenerator
+ */
 function elements(/*$a, $b, ...*/)
 {
-    $arguments = func_get_args();
-    if (count($arguments) == 1) {
-        return Generator\ElementsGenerator::fromArray($arguments[0]);
-    } else {
-        return Generator\ElementsGenerator::fromArray($arguments);
-    }
+    return ElementsGenerator::elements(func_get_args());
 }
-
 
 class ElementsGenerator implements Generator
 {
     private $domain;
 
-    public static function fromArray(array $domain)
+    private static function fromArray(array $domain)
     {
         return new self($domain);
     }
@@ -38,5 +35,18 @@ class ElementsGenerator implements Generator
     public function shrink(GeneratedValue $element)
     {
         return $element;
+    }
+
+    /**
+     * @return ElementsGenerator
+     */
+    public static function elements(/*$a, $b, ...*/)
+    {
+        $arguments = func_get_args();
+        if (count($arguments) == 1) {
+            return self::fromArray($arguments[0]);
+        } else {
+            return self::fromArray($arguments);
+        }
     }
 }

--- a/src/Generator/FloatGenerator.php
+++ b/src/Generator/FloatGenerator.php
@@ -4,9 +4,12 @@ namespace Eris\Generator;
 use Eris\Generator;
 use Eris\Random\RandomRange;
 
+/**
+ * @return FloatGenerator
+ */
 function float()
 {
-    return new FloatGenerator();
+    return FloatGenerator::float();
 }
 
 class FloatGenerator implements Generator
@@ -38,5 +41,13 @@ class FloatGenerator implements Generator
             return GeneratedValueSingle::fromJustValue(max($value - 1.0, 0.0), 'float');
         }
         return GeneratedValueSingle::fromJustValue(0.0, 'float');
+    }
+
+    /**
+     * @return FloatGenerator
+     */
+    public static function float()
+    {
+        return new FloatGenerator();
     }
 }

--- a/src/Generator/FrequencyGenerator.php
+++ b/src/Generator/FrequencyGenerator.php
@@ -10,7 +10,7 @@ use Eris\Random\RandomRange;
  */
 function frequency(/*$frequencyAndGenerator, $frequencyAndGenerator, ...*/)
 {
-    return new FrequencyGenerator(func_get_args());
+    return FrequencyGenerator::frequency(func_get_args());
 }
 
 class FrequencyGenerator implements Generator
@@ -110,5 +110,13 @@ class FrequencyGenerator implements Generator
             );
         }
         return $frequency;
+    }
+
+    /**
+     * @return FrequencyGenerator
+     */
+    public static function frequency(/*$frequencyAndGenerator, $frequencyAndGenerator, ...*/)
+    {
+        return new FrequencyGenerator(func_get_args());
     }
 }

--- a/src/Generator/IntegerGenerator.php
+++ b/src/Generator/IntegerGenerator.php
@@ -3,49 +3,52 @@ namespace Eris\Generator;
 
 use Eris\Generator;
 use Eris\Random\RandomRange;
+use phpDocumentor\Reflection\Types\Integer;
 
 /**
  * Generates a positive or negative integer (with absolute value bounded by
  * the generation size).
+ * @returns IntegerGenerator
  */
 function int()
 {
-    return new IntegerGenerator();
+    return IntegerGenerator::int();
 }
 
 /**
  * Generates a positive integer (bounded by the generation size).
+ * * @returns IntegerGenerator
  */
 function pos()
 {
-    $mustBeStrictlyPositive = function ($n) {
-        return abs($n) + 1;
-    };
-    return new IntegerGenerator($mustBeStrictlyPositive);
+    return IntegerGenerator::pos();
 }
 
+/**
+ * Generates a natural number.
+ * @return IntegerGenerator
+ */
 function nat()
 {
-    $mustBeNatural = function ($n) {
-        return abs($n);
-    };
-    return new IntegerGenerator($mustBeNatural);
+    return IntegerGenerator::nat();
 }
 
 /**
  * Generates a negative integer (bounded by the generation size).
+ * @return IntegerGenerator
  */
 function neg()
 {
-    $mustBeStrictlyNegative = function ($n) {
-        return (-1) * (abs($n) + 1);
-    };
-    return new IntegerGenerator($mustBeStrictlyNegative);
+    return IntegerGenerator::neg();
 }
 
+/**
+ * Generate a byte (integer value in the interval 0 - 255)
+ * @return ChooseGenerator
+ */
 function byte()
 {
-    return new ChooseGenerator(0, 255);
+    return IntegerGenerator::byte();
 }
 
 class IntegerGenerator implements Generator
@@ -109,5 +112,60 @@ class IntegerGenerator implements Generator
         return function ($n) {
             return $n;
         };
+    }
+
+    /**
+     * Generates a positive or negative integer (with absolute value bounded by
+     * the generation size).
+     * @returns IntegerGenerator
+     */
+    public static function int()
+    {
+        return new self();
+    }
+
+    /**
+     * Generates a positive integer (bounded by the generation size).
+     * * @returns IntegerGenerator
+     */
+    public static function pos()
+    {
+        $mustBeStrictlyPositive = function ($n) {
+            return abs($n) + 1;
+        };
+        return new self($mustBeStrictlyPositive);
+    }
+
+    /**
+     * Generates a natural number.
+     * @return IntegerGenerator
+     */
+    public static function nat()
+    {
+        $mustBeNatural = function ($n) {
+            return abs($n);
+        };
+        return new self($mustBeNatural);
+    }
+
+    /**
+     * Generates a negative integer (bounded by the generation size).
+     * @return IntegerGenerator
+     */
+    public static function neg()
+    {
+        $mustBeStrictlyNegative = function ($n) {
+            return (-1) * (abs($n) + 1);
+        };
+        return new self($mustBeStrictlyNegative);
+    }
+
+    /**
+     * Generate a byte (integer value in the interval 0 - 255)
+     * @return ChooseGenerator
+     */
+    public static function byte()
+    {
+        return new ChooseGenerator(0, 255);
     }
 }

--- a/src/Generator/MapGenerator.php
+++ b/src/Generator/MapGenerator.php
@@ -5,19 +5,15 @@ use Eris\Generator;
 use Eris\Random\RandomRange;
 
 // TODO: support calls like ($function . $generator)
-function map(callable $function, Generator $generator)
-{
-    return new MapGenerator($function, $generator);
-}
 
 class MapGenerator implements Generator
 {
-    private $map;
+    private $mapFn;
     private $generator;
     
     public function __construct(callable $map, $generator)
     {
-        $this->map = $map;
+        $this->mapFn = $map;
         $this->generator = $generator;
     }
 
@@ -25,7 +21,7 @@ class MapGenerator implements Generator
     {
         $input = $this->generator->__invoke($_size, $rand);
         return $input->map(
-            $this->map,
+            $this->mapFn,
             'map'
         );
     }
@@ -35,8 +31,13 @@ class MapGenerator implements Generator
         $input = $value->input();
         $shrunkInput = $this->generator->shrink($input);
         return $shrunkInput->map(
-            $this->map,
+            $this->mapFn,
             'map'
         );
+    }
+
+    public static function map(callable $function, Generator $generator)
+    {
+        return new MapGenerator($function, $generator);
     }
 }

--- a/src/Generator/NamesGenerator.php
+++ b/src/Generator/NamesGenerator.php
@@ -4,9 +4,12 @@ namespace Eris\Generator;
 use Eris\Generator;
 use Eris\Random\RandomRange;
 
+/**
+ * @return NamesGenerator
+ */
 function names()
 {
-    return NamesGenerator::defaultDataSet();
+    return NamesGenerator::names();
 }
 
 class NamesGenerator implements Generator
@@ -100,5 +103,13 @@ class NamesGenerator implements Generator
             }
         );
         return array_keys($candidatesWithEqualDistance)[0];
+    }
+
+    /**
+     * @return NamesGenerator
+     */
+    public static function names()
+    {
+        return self::defaultDataSet();
     }
 }

--- a/src/Generator/OneOfGenerator.php
+++ b/src/Generator/OneOfGenerator.php
@@ -9,7 +9,7 @@ use Eris\Random\RandomRange;
  */
 function oneOf(/*$a, $b, ...*/)
 {
-    return new OneOfGenerator(func_get_args());
+    return OneOfGenerator::oneOf(func_get_args());
 }
 
 class OneOfGenerator implements Generator
@@ -34,10 +34,18 @@ class OneOfGenerator implements Generator
     private function allWithSameFrequency($generators)
     {
         return array_map(
-            function ($generator) {
+            static function ($generator) {
                 return [1, $generator];
             },
             $generators
         );
+    }
+
+    /**
+     * @return OneOfGenerator
+     */
+    public static function oneOf(/*$a, $b, ...*/)
+    {
+        return new OneOfGenerator(func_get_args());
     }
 }

--- a/src/Generator/RegexGenerator.php
+++ b/src/Generator/RegexGenerator.php
@@ -19,7 +19,7 @@ use ReverseRegex\Generator\Scope;
  */
 function regex($expression)
 {
-    return new RegexGenerator($expression);
+    return RegexGenerator::regex($expression);
 }
 
 class RegexGenerator implements Generator
@@ -49,5 +49,18 @@ class RegexGenerator implements Generator
     public function shrink(GeneratedValue $value)
     {
         return $value;
+    }
+
+    /**
+     * Note * and + modifiers cause an unbounded number of character to be generated
+     * (up to plus infinity) and as such they are not supported.
+     * Please use {1,N} and {0,N} instead of + and *.
+     *
+     * @param string $expression
+     * @return Generator\RegexGenerator
+     */
+    public static function regex($expression)
+    {
+        return new self($expression);
     }
 }

--- a/src/Generator/SequenceGenerator.php
+++ b/src/Generator/SequenceGenerator.php
@@ -4,13 +4,13 @@ namespace Eris\Generator;
 use Eris\Generator;
 use Eris\Random\RandomRange;
 
+/**
+ * @param Generator $singleElementGenerator
+ * @return SequenceGenerator
+ */
 function seq(Generator $singleElementGenerator)
 {
-    // TODO: Generator::box($singleElementGenerator);
-    if (!($singleElementGenerator instanceof Generator)) {
-        $singleElementGenerator = new Constant($singleElementGenerator);
-    }
-    return new SequenceGenerator($singleElementGenerator);
+    return SequenceGenerator::seq($singleElementGenerator);
 }
 
 class SequenceGenerator implements Generator
@@ -79,5 +79,18 @@ class SequenceGenerator implements Generator
     private function vector($size)
     {
         return new VectorGenerator($size, $this->singleElementGenerator);
+    }
+
+    /**
+     * @param Generator $singleElementGenerator
+     * @return SequenceGenerator
+     */
+    public static function seq(Generator $singleElementGenerator)
+    {
+        // TODO: Generator::box($singleElementGenerator);
+        if (!($singleElementGenerator instanceof Generator)) {
+            $singleElementGenerator = new Constant($singleElementGenerator);
+        }
+        return new self($singleElementGenerator);
     }
 }

--- a/src/Generator/SetGenerator.php
+++ b/src/Generator/SetGenerator.php
@@ -10,7 +10,7 @@ use Eris\Random\RandomRange;
  */
 function set($singleElementGenerator)
 {
-    return new SetGenerator($singleElementGenerator);
+    return SetGenerator::set($singleElementGenerator);
 }
 
 class SetGenerator implements Generator
@@ -59,5 +59,14 @@ class SetGenerator implements Generator
             array_values($input),
             'set'
         );
+    }
+
+    /**
+     * @param Generator $singleElementGenerator
+     * @return SetGenerator
+     */
+    public static function set($singleElementGenerator)
+    {
+        return new SetGenerator($singleElementGenerator);
     }
 }

--- a/src/Generator/StringGenerator.php
+++ b/src/Generator/StringGenerator.php
@@ -4,9 +4,12 @@ namespace Eris\Generator;
 use Eris\Generator;
 use Eris\Random\RandomRange;
 
+/**
+ * @return StringGenerator
+ */
 function string()
 {
-    return new StringGenerator();
+    return StringGenerator::string();
 }
 
 class StringGenerator implements Generator
@@ -31,5 +34,13 @@ class StringGenerator implements Generator
             substr($element->unbox(), 0, -1),
             'string'
         );
+    }
+
+    /**
+     * @return StringGenerator
+     */
+    public static function string()
+    {
+        return new self();
     }
 }

--- a/src/Generator/SubsetGenerator.php
+++ b/src/Generator/SubsetGenerator.php
@@ -13,7 +13,7 @@ use Eris\Generator;
  */
 function subset($input)
 {
-    return new SubsetGenerator($input);
+    return SubsetGenerator::subset($input);
 }
 
 class SubsetGenerator implements Generator
@@ -57,5 +57,14 @@ class SubsetGenerator implements Generator
             array_values($input),
             'subset'
         );
+    }
+
+    /**
+     * @param array $input
+     * @return SubsetGenerator
+     */
+    public static function subset($input)
+    {
+        return new SubsetGenerator($input);
     }
 }

--- a/src/Generator/TupleGenerator.php
+++ b/src/Generator/TupleGenerator.php
@@ -9,17 +9,11 @@ use Eris\Random\RandomRange;
  * tuple(Generator, Generator, Generator...)
  * Or an array of generators:
  * tuple(array $generators)
- * @return Generator\TupleGenerator
+ * @return TupleGenerator
  */
 function tuple()
 {
-    $arguments = func_get_args();
-    if (is_array($arguments[0])) {
-        $generators = $arguments[0];
-    } else {
-        $generators = $arguments;
-    }
-    return new TupleGenerator($generators);
+    return TupleGenerator::tuple(func_get_args());
 }
 
 class TupleGenerator implements Generator
@@ -96,6 +90,24 @@ class TupleGenerator implements Generator
 
         return $this->optionsFromTheseGenerators($this->generators, $input)
             ->remove($tuple);
+    }
+
+    /**
+     * One Generator for each member of the Tuple:
+     * tuple(Generator, Generator, Generator...)
+     * Or an array of generators:
+     * tuple(array $generators)
+     * @return TupleGenerator
+     */
+    public static function tuple()
+    {
+        $arguments = func_get_args();
+        if (is_array($arguments[0])) {
+            $generators = $arguments[0];
+        } else {
+            $generators = $arguments;
+        }
+        return new self($generators);
     }
 
     private function ensureAreAllGenerators(array $generators)

--- a/src/Generator/VectorGenerator.php
+++ b/src/Generator/VectorGenerator.php
@@ -6,7 +6,7 @@ use Eris\Random\RandomRange;
 
 function vector($size, Generator $elementsGenerator)
 {
-    return new VectorGenerator($size, $elementsGenerator);
+    return VectorGenerator::vector($size, $elementsGenerator);
 }
 
 class VectorGenerator implements Generator
@@ -32,5 +32,10 @@ class VectorGenerator implements Generator
     public function shrink(GeneratedValue $vector)
     {
         return $this->generator->shrink($vector);
+    }
+
+    public static function vector($size, Generator $elementsGenerator)
+    {
+        return new self($size, $elementsGenerator);
     }
 }

--- a/src/Quantifier/ForAll.php
+++ b/src/Quantifier/ForAll.php
@@ -110,7 +110,8 @@ class ForAll
     }
 
     // Alias for __invoke.
-    public function then(callable $assertion){
+    public function then(callable $assertion)
+    {
         return $this->__invoke($assertion);
     }
 

--- a/src/Quantifier/ForAll.php
+++ b/src/Quantifier/ForAll.php
@@ -109,6 +109,11 @@ class ForAll
         return $this;
     }
 
+    // Alias for __invoke.
+    public function then(callable $assertion){
+        return $this->__invoke($assertion);
+    }
+
     public function __invoke(callable $assertion)
     {
         $sizes = Size::withTriangleGrowth($this->maxSize)

--- a/test/Generator/IntegerGeneratorTest.php
+++ b/test/Generator/IntegerGeneratorTest.php
@@ -74,13 +74,13 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testPosAlreadyStartsFromStrictlyPositiveValues()
     {
-        $generator = pos();
+        $generator = IntegerGenerator::pos();
         $this->assertGreaterThan(0, $generator->__invoke(0, $this->rand)->unbox());
     }
 
     public function testPosNeverShrinksToZero()
     {
-        $generator = pos();
+        $generator = IntegerGenerator::pos();
         $value = $generator->__invoke(10, $this->rand);
         for ($i = 0; $i < 20; $i++) {
             $value = $generator->shrink(GeneratedValueOptions::mostPessimisticChoice($value));
@@ -90,13 +90,13 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testNegAlreadyStartsFromStrictlyNegativeValues()
     {
-        $generator = neg();
+        $generator = IntegerGenerator::neg();
         $this->assertLessThan(0, $generator->__invoke(0, $this->rand)->unbox());
     }
 
     public function testNegNeverShrinksToZero()
     {
-        $generator = neg();
+        $generator = IntegerGenerator::neg();
         $value = $generator->__invoke(10, $this->rand);
         for ($i = 0; $i < 20; $i++) {
             $value = $generator->shrink(GeneratedValueOptions::mostPessimisticChoice($value));
@@ -106,7 +106,7 @@ class IntegerGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testNatStartsFromZero()
     {
-        $generator = nat();
+        $generator = IntegerGenerator::nat();
         $this->assertEquals(0, $generator->__invoke(0, $this->rand)->unbox());
     }
 }

--- a/test/SampleTest.php
+++ b/test/SampleTest.php
@@ -2,6 +2,9 @@
 
 namespace Eris;
 
+use Eris\Generator\IntegerGenerator;
+use Eris\Generator\SuchThatGenerator;
+
 class SampleTest extends \PHPUnit_Framework_TestCase
 {
     use TestTrait;
@@ -10,9 +13,9 @@ class SampleTest extends \PHPUnit_Framework_TestCase
     {
         $times         = 100;
         $generatorSize = 100;
-        $generator     = Generator\suchThat(function ($n) {
+        $generator     = SuchThatGenerator::suchThat(function ($n) {
             return $n > 10;
-        }, Generator\nat());
+        }, IntegerGenerator::nat());
         $sample        = $this->sample($generator, $times, $generatorSize);
         $this->assertNotEmpty(count($sample->collected()));
     }


### PR DESCRIPTION
Moved all factory functions inside Generator classes, such that PhpStan can find them.
For backwards compatibility, kept the original namespaced factory functions and changed their body to simply call the functions on the Generator classes.
Added a literal alias 'then' in ForAll, because PhpStan could not find the declared alias.
Added some missing PhpDoc