### PR TITLE
Use square brackets for string indexing

### DIFF
--- a/src/Generator/SubsetGenerator.php
+++ b/src/Generator/SubsetGenerator.php
@@ -33,7 +33,7 @@ class SubsetGenerator implements Generator
         $binaryDescription = str_pad(decbin($subsetIndex), count($this->universe), "0", STR_PAD_LEFT);
         $subset = [];
         for ($i = 0; $i < strlen($binaryDescription); $i++) {
-            $elementPresent = $binaryDescription{$i};
+            $elementPresent = $binaryDescription[$i];
             if ($elementPresent == "1") {
                 $subset[] = $this->universe[$i];
             }


### PR DESCRIPTION
Curly brackets are deprecated in PHP 7.4: https://wiki.php.net/rfc/deprecate_curly_braces_array_access