### PR TITLE
Corrected Invalid Docblock

### DIFF
--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -147,7 +147,7 @@ trait TestTrait
     }
 
     /**
-     * @param integer|DateInterval
+     * @param integer|DateInterval $limit
      * @return self
      */
     protected function limitTo($limit)


### PR DESCRIPTION
Badly-formatted @param in docblock for Eris\TestTrait::limitTo (see https://psalm.dev/008) corrected