### PR TITLE
Added "when" method alias. Annotated "and" method.

### DIFF
--- a/src/Quantifier/ForAll.php
+++ b/src/Quantifier/ForAll.php
@@ -87,7 +87,7 @@ class ForAll
      * when(Antecedent $antecedent)
      * @return self
      */
-    public function when(/* see docblock */): self
+    public function when(/* see docblock */)
     {
         $arguments = func_get_args();
         if ($arguments[0] instanceof Antecedent) {
@@ -105,12 +105,12 @@ class ForAll
         return $this;
     }
 
-    public function and(): self
+    public function and()
     {
         return $this->when(...\func_get_args());
     }
 
-    public function __invoke(callable $assertion): void
+    public function __invoke(callable $assertion)
     {
         $sizes = Size::withTriangleGrowth($this->maxSize)
             ->limit($this->iterations);
@@ -190,7 +190,7 @@ class ForAll
         }
     }
 
-    public function then(callable $assertion): void
+    public function then(callable $assertion)
     {
         $this->__invoke($assertion);
     }

--- a/src/Quantifier/ForAll.php
+++ b/src/Quantifier/ForAll.php
@@ -14,7 +14,6 @@ use RuntimeException;
 use Eris\Listener;
 use Eris\Random\RandomRange;
 
-
 /**
  * @method self and()
  */


### PR DESCRIPTION
When using Eris, the missing implementation of the "when" and "and" methods gets flagged by static analyzers.
To overcome this issue i implemented the "when" method as an alias to "__invoke" and additionally annotaded the "and" method in the class-level docblock, as certain reserved key-words cannot be used as method names in PHP 5.