### PR TITLE
Replaces usage of unsupported internal method

### DIFF
--- a/src/Facade.php
+++ b/src/Facade.php
@@ -20,7 +20,7 @@ class Facade
      * sadly this facade has no option to retrieve annotations of testcases
      * @return array
      */
-    protected function getAnnotations()
+    protected function getTestCaseAnnotations()
     {
         return array();
     }

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -42,7 +42,7 @@ trait TestTrait
     /**
      * @return array 
      */
-    public function getAnnotations()
+    public function getTestCaseAnnotations()
     {
         //from TestCase of PHPunit
         return \PHPUnit\Util\Test::parseTestMethodAnnotations(
@@ -63,7 +63,7 @@ trait TestTrait
                 return !($listener instanceof MinimumEvaluations);
             }
         );
-        $tags = $this->getAnnotations();
+        $tags = $this->getTestCaseAnnotations();
         $this->withRand($this->getAnnotationValue($tags, 'eris-method', 'rand', 'strval'));
         $this->iterations = $this->getAnnotationValue($tags, 'eris-repeat', 100, 'intval');
         $this->shrinkingTimeLimit = $this->getAnnotationValue($tags, 'eris-shrink', null, 'intval');

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -40,6 +40,18 @@ trait TestTrait
     }
 
     /**
+     * @return array 
+     */
+    public function getAnnotations()
+    {
+        //from TestCase of PHPunit
+        return \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($this),
+            $this->getName(false)
+        );
+    }
+
+    /**
      * @before
      */
     public function erisSetup()
@@ -51,7 +63,7 @@ trait TestTrait
                 return !($listener instanceof MinimumEvaluations);
             }
         );
-        $tags = $this->getAnnotations();//from TestCase of PHPunit
+        $tags = $this->getAnnotations();
         $this->withRand($this->getAnnotationValue($tags, 'eris-method', 'rand', 'strval'));
         $this->iterations = $this->getAnnotationValue($tags, 'eris-repeat', 100, 'intval');
         $this->shrinkingTimeLimit = $this->getAnnotationValue($tags, 'eris-shrink', null, 'intval');

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -44,6 +44,9 @@ trait TestTrait
      */
     public function getTestCaseAnnotations()
     {
+        if(\method_exists($this, 'getAnnotations')) {
+            return $this->getAnnotations();
+        }
         //from TestCase of PHPunit
         return \PHPUnit\Util\Test::parseTestMethodAnnotations(
             get_class($this),

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -40,11 +40,11 @@ trait TestTrait
     }
 
     /**
-     * @return array 
+     * @return array
      */
     public function getTestCaseAnnotations()
     {
-        if(\method_exists($this, 'getAnnotations')) {
+        if (\method_exists($this, 'getAnnotations')) {
             return $this->getAnnotations();
         }
         //from TestCase of PHPunit


### PR DESCRIPTION
PHPUnit had an internal method getAnnotations which was removed in latest version.
This change avoids uses php unit's supported methods
to fetch annotations so that the library can work with latest
versions of phpunit

Relates to #142 
