### PR TITLE
Drop support for PHP < 7.4, PHPUnit < 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.1, 7.4, 8.0]
+        php: [7.4, 8.0]
         dependencies:
           - "lowest"
           - "highest"
@@ -38,8 +38,6 @@ jobs:
           - { phpunit: 9, php: 8.1 }
           - { phpunit: 9, php: 8.0 }
           - { phpunit: 8, php: 7.4 }
-          - { phpunit: 7, php: 7.3 }
-          - { phpunit: 6, php: 7.1 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0]
         dependencies:
           - "lowest"
           - "highest"
-#        include:
-#          - { php: 8.1, dependencies: "highest" }
-#          - { php: 8.2, dependencies: "highest" }
+        include:
+          - { php: 8.1, dependencies: "highest" }
+          - { php: 8.2, dependencies: "highest" }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -35,6 +35,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - { phpunit: 9, php: 8.2 }
           - { phpunit: 9, php: 8.1 }
           - { phpunit: 9, php: 8.0 }
           - { phpunit: 8, php: 7.4 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1, 8.2]
         dependencies:
           - "lowest"
           - "highest"
-        include:
-          - { php: 8.1, dependencies: "highest" }
-          - { php: 8.2, dependencies: "highest" }
+#        include:
+#          - { php: 8.1, dependencies: "highest" }
+#          - { php: 8.2, dependencies: "highest" }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/_build
 docker-compose.override.yml
 .psalm-cache/
 .idea
+.php-cs-fixer.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The project follows [semantic versioning](http://semver.org/). `BC` stands for a change that impacts `Backward Compatibility`.
 
 ## [Unreleased]
+### Added
+* `ilario-pierbattista/reverse-regex` as substitute peer dependency of `icomefromthenet/reverse-regex`.
+* Support for PHP 8.2
+### Removed
+* Support for PHP < 7.4
+* Support for PHPUnit < 8
 
 ## [0.13.0] - 2021-12-17
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ run-php-7.4:
 .PHONY: run-php-8.1
 run-php-8.1:
 	docker-compose run php-8.1 sh
+
+.PHONY: run-php-8.2
+run-php-8.2:
+	docker-compose run php-8.2 sh

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ In property-based testing, several properties that the System Under Test must re
 
 ## Compatibility
 
-- PHP 7.1, 7.2, 7.3, 7.4, 8.0, 8.1
-- PHPUnit 6.x, 7.x, 8.x, 9.x
+- PHP 7.4, 8.0, 8.1, 8.2
+- PHPUnit 8.x, 9.x
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     {
         "phpunit/phpunit": "Standard way to run generated test cases",
         "icomefromthenet/reverse-regex": "v0.0.6.3 for the regex() Generator",
-        "ilario-pierbattista/reverse-regex": "v0.0.6.3 for the regex() Generator"
+        "ilario-pierbattista/reverse-regex": "0.3.1 for the regex() Generator (alternative to icomefromthenet/reverse-regex) "
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpunit/phpunit": "^8 || ^9",
         "sebastian/comparator": ">=2.1.3",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "ilario-pierbattista/reverse-regex": "dev-doctrine_lexer",
+        "ilario-pierbattista/reverse-regex": "^0.3.1",
         "phpstan/phpstan": "^1.10",
         "psalm/phar": "^5.4",
         "rector/rector": "^0.15"

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     "require-dev": {
         "phpunit/phpunit": ">=7",
         "sebastian/comparator": ">=2.1.3",
-        "friendsofphp/php-cs-fixer": "^2.0",
-        "ilario-pierbattista/reverse-regex": ">=v0.0.6.3",
-        "phpstan/phpstan": "^1.9.4",
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "ilario-pierbattista/reverse-regex": "dev-doctrine_lexer",
+        "phpstan/phpstan": "^1.10",
         "psalm/phar": "^5.4",
-        "rector/rector": "^0.12.14"
+        "rector/rector": "^0.15"
     },
     "suggest":
     {

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
         ],
         "phpstan-baseline": [
             "vendor/bin/phpstan analyse -c phpstan.neon --generate-baseline"
+        ],
+        "rector": [
+            "vendor/bin/rector"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,16 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.4"
     },
     "require-dev": {
         "phpunit/phpunit": ">=7",
-        "sebastian/comparator": ">=1.2.4",
+        "sebastian/comparator": ">=2.1.3",
         "friendsofphp/php-cs-fixer": "^2.0",
-        "ilario-pierbattista/reverse-regex": "v0.0.6.3",
-        "phpstan/phpstan": "^1.2",
-        "psalm/phar": "^5.4"
+        "ilario-pierbattista/reverse-regex": ">=v0.0.6.3",
+        "phpstan/phpstan": "^1.9.4",
+        "psalm/phar": "^5.4",
+        "rector/rector": "^0.12.14"
     },
     "suggest":
     {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=7",
+        "phpunit/phpunit": "^8 || ^9",
         "sebastian/comparator": ">=2.1.3",
         "friendsofphp/php-cs-fixer": "^3.0",
         "ilario-pierbattista/reverse-regex": "dev-doctrine_lexer",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,12 @@ services:
       - .:/usr/src/eris
     user: 1000:1000
     working_dir: /usr/src/eris
+  php-8.2:
+    build:
+      context: .docker
+      args:
+        BASE_IMAGE: php:8.2-cli-alpine3.16
+    volumes:
+      - .:/usr/src/eris
+    user: 1000:1000
+    working_dir: /usr/src/eris

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src'
+    ]);
+
+    // Define what rule sets will be applied
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_74);
+
+    // get services (needed for register a single rule)
+    // $services = $containerConfigurator->services();
+
+    // register a single rule
+    // $services->set(TypedPropertyRector::class);
+};

--- a/rector.php
+++ b/rector.php
@@ -2,24 +2,21 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    // get parameters
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
         __DIR__ . '/src'
     ]);
 
-    // Define what rule sets will be applied
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_74);
-
-    // get services (needed for register a single rule)
-    // $services = $containerConfigurator->services();
-
     // register a single rule
-    // $services->set(TypedPropertyRector::class);
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+    $rectorConfig->import(LevelSetList::UP_TO_PHP_74);
+
+    // define sets of rules
+    //    $rectorConfig->sets([
+    //        LevelSetList::UP_TO_PHP_74
+    //    ]);
 };

--- a/test/Generator/BindGeneratorTest.php
+++ b/test/Generator/BindGeneratorTest.php
@@ -25,7 +25,7 @@ class BindGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGeneratesAGeneratedValueObject(): void
     {
         $generator = new BindGenerator(
-        // TODO: order of parameters should be consistent with map, or not?
+            // TODO: order of parameters should be consistent with map, or not?
             ConstantGenerator::box(4),
             function ($n) {
                 return new ChooseGenerator($n, $n + 10);


### PR DESCRIPTION
Also
- drop support for old versions of PHPUnit
- configure and run Rector for refactoring