### PR TITLE
chore: Promote annotations @before and @beforeClass to attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         include:
           - { php: 8.1, dependencies: "highest" }
           - { php: 8.2, dependencies: "highest" }
+          - { php: 8.3, dependencies: "highest" }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -35,8 +36,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - { phpunit: 10, php: 8.2 }
           - { phpunit: 10, php: 8.1 }
+          - { phpunit: 10, php: 8.2 }
+          - { phpunit: 10, php: 8.3 }
+          - { phpunit: 11, php: 8.1 }
+          - { phpunit: 11, php: 8.2 }
+          - { phpunit: 11, php: 8.3 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
           - { phpunit: 10, php: 8.1 }
           - { phpunit: 10, php: 8.2 }
           - { phpunit: 10, php: 8.3 }
-          - { phpunit: 11, php: 8.1 }
           - { phpunit: 11, php: 8.2 }
           - { phpunit: 11, php: 8.3 }
     steps:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ In property-based testing, several properties that the System Under Test must re
 
 ## Compatibility
 
-- PHP 8.1, 8.2
-- PHPUnit 10.x
+- PHP 8.1, 8.2, 8.3
+- PHPUnit 10.x, 11.x
 
 ## Installation
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -436,11 +436,6 @@ parameters:
 			path: src/Generator/GeneratedValueSingle.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(callable\\|Constraint\\)\\: Unexpected token \"\\\\n     \", expected variable at offset 37$#"
-			count: 1
-			path: src/Generator/SuchThatGenerator.php
-
-		-
 			message: "#^Call to an undefined method Eris\\\\Generator\\\\GeneratedValue\\<array\\<int, mixed\\>\\>\\:\\:first\\(\\)\\.$#"
 			count: 1
 			path: test/Generator/SequenceGeneratorTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,307 +1,161 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
+<files psalm-version="5.22.2@d768d914152dbbf3486c36398802f74e80cfde48">
+  <file src="examples/AssociativeArrayTest.php">
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[$array]]></code>
+      <code><![CDATA[$array]]></code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="examples/NamesTest.php">
     <ForbiddenCode>
-      <code>var_dump($name)</code>
+      <code><![CDATA[var_dump($name)]]></code>
       <code><![CDATA[var_dump($sample->collected())]]></code>
     </ForbiddenCode>
   </file>
   <file src="examples/ShrinkingTest.php">
     <ForbiddenCode>
-      <code>var_dump($string)</code>
+      <code><![CDATA[var_dump($string)]]></code>
     </ForbiddenCode>
   </file>
   <file src="examples/SubsetTest.php">
     <ForbiddenCode>
-      <code>var_dump($set)</code>
+      <code><![CDATA[var_dump($set)]]></code>
     </ForbiddenCode>
   </file>
   <file src="src/Generator.php">
     <InvalidDocblock>
-      <code>public function __invoke($size, Random\RandomRange $rand);</code>
-      <code>public function shrink(GeneratedValue $element);</code>
+      <code><![CDATA[public function __invoke($size, Random\RandomRange $rand);]]></code>
+      <code><![CDATA[public function shrink(GeneratedValue $element);]]></code>
     </InvalidDocblock>
   </file>
   <file src="src/Generator/AssociativeArrayGenerator.php">
     <InvalidArrayOffset>
-      <code>$associativeArray[$key]</code>
+      <code><![CDATA[$associativeArray[$key]]]></code>
     </InvalidArrayOffset>
   </file>
   <file src="src/Generator/DateGenerator.php">
     <InvalidArgument>
-      <code>$halvedOffset</code>
+      <code><![CDATA[$halvedOffset]]></code>
     </InvalidArgument>
   </file>
   <file src="src/Generator/GeneratedValueOptions.php">
     <ParamNameMismatch>
-      <code>$callable</code>
+      <code><![CDATA[$callable]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/GeneratedValueSingle.php">
     <InvalidDocblock>
-      <code>public static function fromJustValue($value, $generatorName = null)</code>
-      <code>public static function fromValueAndInput($value, $input, $generatorName = null)</code>
+      <code><![CDATA[public static function fromJustValue($value, $generatorName = null)]]></code>
+      <code><![CDATA[public static function fromValueAndInput($value, $input, $generatorName = null)]]></code>
     </InvalidDocblock>
     <InvalidReturnStatement>
-      <code>new ArrayIterator([
+      <code><![CDATA[new ArrayIterator([
             $this
-        ])</code>
+        ])]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code>\Traversable</code>
+      <code><![CDATA[\Traversable]]></code>
     </InvalidReturnType>
   </file>
   <file src="src/Generator/MapGenerator.php">
     <ParamNameMismatch>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/NamesGenerator.php">
     <ParamNameMismatch>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/RegexGenerator.php">
     <ParamNameMismatch>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/SequenceGenerator.php">
     <InvalidMethodCall>
-      <code>unbox</code>
+      <code><![CDATA[unbox]]></code>
     </InvalidMethodCall>
     <ParamNameMismatch>
-      <code>$sequence</code>
+      <code><![CDATA[$sequence]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/SetGenerator.php">
     <InvalidMethodCall>
-      <code>unbox</code>
+      <code><![CDATA[unbox]]></code>
     </InvalidMethodCall>
     <ParamNameMismatch>
-      <code>$set</code>
+      <code><![CDATA[$set]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/SubsetGenerator.php">
     <InvalidArgument>
-      <code>$maximumSubsetIndex</code>
+      <code><![CDATA[$maximumSubsetIndex]]></code>
     </InvalidArgument>
     <ParamNameMismatch>
-      <code>$set</code>
+      <code><![CDATA[$set]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/SuchThatGenerator.php">
-    <InvalidDocblock>
-      <code>public function __construct($filter, $generator, $maximumAttempts = 100)</code>
-    </InvalidDocblock>
     <ParamNameMismatch>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/TupleGenerator.php">
     <ParamNameMismatch>
-      <code>$tuple</code>
+      <code><![CDATA[$tuple]]></code>
     </ParamNameMismatch>
   </file>
   <file src="src/Generator/VectorGenerator.php">
     <ParamNameMismatch>
-      <code>$vector</code>
+      <code><![CDATA[$vector]]></code>
     </ParamNameMismatch>
   </file>
+  <file src="src/Shrinker/Multiple.php">
+    <UndefinedVariable>
+      <code><![CDATA[$elementsAfterShrink]]></code>
+    </UndefinedVariable>
+  </file>
   <file src="src/TestTrait.php">
-    <InternalClass>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-    </InternalClass>
     <InternalMethod>
-      <code><![CDATA[\PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        )]]></code>
-      <code>getName</code>
+      <code><![CDATA[name]]></code>
+      <code><![CDATA[toString]]></code>
     </InternalMethod>
+  </file>
+  <file src="test/Generator/AssociativeArrayGeneratorTest.php">
+    <InvalidArgument>
+      <code><![CDATA[$array]]></code>
+    </InvalidArgument>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[$array]]></code>
+      <code><![CDATA[$array]]></code>
+      <code><![CDATA[$array]]></code>
+      <code><![CDATA[$array]]></code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="test/Generator/SequenceGeneratorTest.php">
     <UndefinedInterfaceMethod>
-      <code>first</code>
+      <code><![CDATA[first]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Generator/SubsetGeneratorTest.php">
     <InvalidArgument>
-      <code>$subsetSizes</code>
+      <code><![CDATA[$subsetSizes]]></code>
     </InvalidArgument>
   </file>
   <file src="test/Generator/SuchThatGeneratorTest.php">
     <UndefinedInterfaceMethod>
-      <code>last</code>
+      <code><![CDATA[last]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Generator/TupleGeneratorTest.php">
     <InvalidMethodCall>
-      <code>generatorName</code>
-      <code>generatorName</code>
-      <code>generatorName</code>
-      <code>unbox</code>
-      <code>unbox</code>
-      <code>unbox</code>
+      <code><![CDATA[generatorName]]></code>
+      <code><![CDATA[generatorName]]></code>
+      <code><![CDATA[generatorName]]></code>
+      <code><![CDATA[unbox]]></code>
+      <code><![CDATA[unbox]]></code>
+      <code><![CDATA[unbox]]></code>
     </InvalidMethodCall>
   </file>
   <file src="test/Listener/LogTest.php">
@@ -314,16 +168,11 @@
       <code><![CDATA[new AssertionFailedError("Failed asserting that...")]]></code>
     </InternalMethod>
     <NullArgument>
-      <code>null</code>
-      <code>null</code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
     </NullArgument>
     <TooManyArguments>
-      <code>shrinking</code>
+      <code><![CDATA[shrinking]]></code>
     </TooManyArguments>
-  </file>
-  <file src="test/PHPUnitDeprecationHelper.php">
-    <InvalidArgument>
-      <code>$haystack</code>
-    </InvalidArgument>
   </file>
 </files>

--- a/src/Generator/SuchThatGenerator.php
+++ b/src/Generator/SuchThatGenerator.php
@@ -37,6 +37,9 @@ class SuchThatGenerator implements Generator
     private $generator;
     private $maximumAttempts;
 
+    /**
+     * @param callable|Constraint $filter
+     */
     public function __construct($filter, $generator, $maximumAttempts = 100)
     {
         $this->filter = $filter;

--- a/src/Generator/SuchThatGenerator.php
+++ b/src/Generator/SuchThatGenerator.php
@@ -36,10 +36,7 @@ class SuchThatGenerator implements Generator
     private $filter;
     private $generator;
     private $maximumAttempts;
-    
-    /**
-     * @param callable|Constraint
-     */
+
     public function __construct($filter, $generator, $maximumAttempts = 100)
     {
         $this->filter = $filter;

--- a/src/TestTrait.php
+++ b/src/TestTrait.php
@@ -3,7 +3,6 @@ namespace Eris;
 
 use BadMethodCallException;
 use DateInterval;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Eris\Attributes\ErisDuration;
 use Eris\Attributes\ErisMethod;
 use Eris\Attributes\ErisRatio;
@@ -16,6 +15,8 @@ use Eris\Random\MtRandSource;
 use Eris\Random\RandomRange;
 use Eris\Random\RandSource;
 use Eris\Shrinker\ShrinkerFactory;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use Throwable;
 
 trait TestTrait
@@ -34,9 +35,7 @@ trait TestTrait
     protected $seed;
     protected $shrinkingTimeLimit;
 
-    /**
-     * @beforeClass
-     */
+    #[BeforeClass]
     public static function erisSetupBeforeClass()
     {
         foreach (['Generator', 'Antecedent', 'Listener', 'Random'] as $namespace) {
@@ -77,9 +76,7 @@ trait TestTrait
         ];
     }
 
-    /**
-     * @before
-     */
+    #[Before]
     public function erisSetup()
     {
         $this->seedingRandomNumberGeneration();

--- a/test/ExampleEnd2EndTest.php
+++ b/test/ExampleEnd2EndTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Eris;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SimpleXMLElement;
 
 class ExampleEnd2EndTest extends \PHPUnit\Framework\TestCase
@@ -37,9 +38,7 @@ class ExampleEnd2EndTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider fullyGreenTestFiles
-     */
+    #[DataProvider('fullyGreenTestFiles')]
     public function testAllTestClassesWhichAreFullyGreen($testCaseFileName)
     {
         $this->runExample($testCaseFileName);

--- a/test/Generator/NamesGeneratorTest.php
+++ b/test/Generator/NamesGeneratorTest.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use Eris\Random\RandomRange;
 use Eris\Random\RandSource;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NamesGeneratorTest extends \PHPUnit\Framework\TestCase
 {
@@ -54,9 +55,7 @@ class NamesGeneratorTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider namesToShrink
-     */
+    #[DataProvider('namesToShrink')]
     public function testShrinksToTheNameWithTheImmediatelyLowerLengthWhichHasTheMinimumDistance($shrunk, $original): void
     {
         $generator = NamesGenerator::defaultDataSet();

--- a/test/Generator/RegexGeneratorTest.php
+++ b/test/Generator/RegexGeneratorTest.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use Eris\Random\RandomRange;
 use Eris\Random\RandSource;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RegexGeneratorTest extends \PHPUnit\Framework\TestCase
 {
@@ -33,9 +34,7 @@ class RegexGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->rand = new RandomRange(new RandSource());
     }
 
-    /**
-     * @dataProvider supportedRegexes
-     */
+    #[DataProvider('supportedRegexes')]
     public function testGeneratesOnlyValuesThatMatchTheRegex($expression)
     {
         $generator = new RegexGenerator($expression);

--- a/test/Generator/TupleGeneratorTest.php
+++ b/test/Generator/TupleGeneratorTest.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use Eris\Random\RandomRange;
 use Eris\Random\RandSource;
+use PHPUnit\Framework\Attributes\Depends;
 
 class TupleGeneratorTest extends \PHPUnit\Framework\TestCase
 {
@@ -129,9 +130,7 @@ class TupleGeneratorTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @depends testShrinkingMultipleOptionsOfOneGenerator
-     */
+    #[Depends('testShrinkingMultipleOptionsOfOneGenerator')]
     public function testShrinkingMultipleOptionsOfMoreThanOneSingleShrinkingGenerator(): void
     {
         $generator = new TupleGenerator([
@@ -161,9 +160,7 @@ class TupleGeneratorTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @depends testShrinkingMultipleOptionsOfOneGenerator
-     */
+    #[Depends('testShrinkingMultipleOptionsOfOneGenerator')]
     public function testShrinkingMultipleOptionsOfMoreThanOneMultipleShrinkingGenerator(): void
     {
         $generator = new TupleGenerator([

--- a/test/PHPUnitCommandTest.php
+++ b/test/PHPUnitCommandTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Eris;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class PHPUnitCommandTest extends \PHPUnit\Framework\TestCase
 {
     public static function commandExamples()
@@ -17,9 +19,7 @@ class PHPUnitCommandTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider commandExamples
-     */
+    #[DataProvider('commandExamples')]
     public function testItCanComposeFrom($name, $fullString)
     {
         $command = PHPUnitCommand::fromSeedAndName(42, $name);

--- a/test/Quantifier/SizeTest.php
+++ b/test/Quantifier/SizeTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Eris\Quantifier;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class SizeTest extends \PHPUnit\Framework\TestCase
 {
     public function testProducesAListOfSizesIncreasingThemTriangularly()
@@ -41,9 +43,7 @@ class SizeTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider limits
-     */
+    #[DataProvider('limits')]
     public function testCoversAUniformSubsetWhenLimitedToTheNumberOfIterations($limit)
     {
         $size = Size::withTriangleGrowth(1000)

--- a/test/Random/MersenneTwisterTest.php
+++ b/test/Random/MersenneTwisterTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Eris\Random;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class MersenneTwisterTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp(): void
@@ -8,12 +10,6 @@ class MersenneTwisterTest extends \PHPUnit\Framework\TestCase
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('MersenneTwister class does not support HHVM');
         }
-        $this->enableAssertions();
-    }
-
-    public function tearDown(): void
-    {
-        $this->disableAssertions();
     }
 
     public static function sequences()
@@ -25,10 +21,8 @@ class MersenneTwisterTest extends \PHPUnit\Framework\TestCase
             [0xfffffffffffffff, 100],
         ];
     }
-    
-    /**
-     * @dataProvider sequences
-     */
+
+    #[DataProvider('sequences')]
     public function testGeneratesTheSameSequenceAsThePythonOracle($seed, $sample)
     {
         $twister = new MersenneTwister();
@@ -56,18 +50,5 @@ class MersenneTwisterTest extends \PHPUnit\Framework\TestCase
         foreach ($bins as $count) {
             $this->assertGreaterThan(400, $count);
         }
-    }
-
-    private function enableAssertions()
-    {
-        assert_options(ASSERT_ACTIVE, 1);
-        assert_options(ASSERT_CALLBACK, function ($file, $line, $code) {
-            throw new \LogicException($code);
-        });
-    }
-
-    private function disableAssertions()
-    {
-        assert_options(ASSERT_ACTIVE, 0);
     }
 }

--- a/test/Shrinker/MultipleTest.php
+++ b/test/Shrinker/MultipleTest.php
@@ -5,6 +5,7 @@ use Eris\Generator\GeneratedValueSingle;
 use Eris\Generator\IntegerGenerator;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 
 class MultipleTest extends \PHPUnit\Framework\TestCase
@@ -43,10 +44,8 @@ class MultipleTest extends \PHPUnit\Framework\TestCase
             ['startingPoint' => 100000],
         ];
     }
-    
-    /**
-     * @dataProvider originallyFailedTests
-     */
+
+    #[DataProvider('originallyFailedTests')]
     public function testMultipleBranchesConvergeFasterThanLinearShrinking($startingPoint)
     {
         try {


### PR DESCRIPTION
Fix #174

Opening this pull request to solve deprecations happening with PHPUnit 11, such as `Metadata found in doc-comment for method SomeClass::erisSetup(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.`

- Convert `@before` and `@beforeClass` annotations to attributes
- Update the README.md too.
- Update PHPStan baseline, to solve PHPStan errors
- Solve own test deprecations (mostly linked to the `@DataProvider` annotation)
- Update test matrix to account for PHPUnit11 and PHP8.3