### PR TITLE
Use configured random source for set size

### DIFF
--- a/src/Generator/SetGenerator.php
+++ b/src/Generator/SetGenerator.php
@@ -29,7 +29,7 @@ class SetGenerator implements Generator
 
     public function __invoke($size, RandomRange $rand)
     {
-        $setSize = rand(0, $size);
+        $setSize = $rand->rand(0, $size);
         $set = [];
         $input = [];
         $trials = 0;

--- a/test/Generator/SetGeneratorTest.php
+++ b/test/Generator/SetGeneratorTest.php
@@ -3,6 +3,7 @@ namespace Eris\Generator;
 
 use Eris\Random\RandomRange;
 use Eris\Random\RandSource;
+use Eris\Random\Source;
 
 class SetGeneratorTest extends \PHPUnit\Framework\TestCase
 {
@@ -59,6 +60,34 @@ class SetGeneratorTest extends \PHPUnit\Framework\TestCase
             $generated = $generator($size, $this->rand)->unbox();
             $this->assertNoRepeatedElements($generated);
         }
+    }
+
+    public function testUsesTheConfiguredRandomSourceToChooseTheSetSize()
+    {
+        $source = new class implements Source {
+            public $calls = 0;
+
+            public function seed($seed)
+            {
+                return $this;
+            }
+
+            public function extractNumber()
+            {
+                $this->calls++;
+                return 0;
+            }
+
+            public function max()
+            {
+                return 100;
+            }
+        };
+        $generator = new SetGenerator(new ConstantGenerator(42));
+
+        $generator(5, new RandomRange($source));
+
+        $this->assertSame(1, $source->calls);
     }
 
     public function testStopsBeforeInfiniteLoopsInTryingToExtractNewElementsToPutInTheSt()


### PR DESCRIPTION
SetGenerator currently uses global `rand()` to choose its target size, even
though generation receives a configured `RandomRange`. Consequently,
unrelated calls to PHP's global RNG can change the generated set despite Eris
using a separately seeded random source.

Use the supplied `RandomRange`, consistently with the other generators. Add a
regression with an injected `Source` proving that set-size selection goes
through the configured source.
