### PR TITLE
Handle single-iteration property limits

### DIFF
--- a/examples/LimitToTest.php
+++ b/examples/LimitToTest.php
@@ -21,6 +21,17 @@ class LimitToTest extends \PHPUnit\Framework\TestCase
             });
     }
 
+    #[ErisRepeat(repeat: 1)]
+    public function testSingleIterationCanBeConfigured()
+    {
+        $this->forAll(
+            Generators::int()
+        )
+            ->then(function ($value) {
+                static::assertIsInt($value);
+            });
+    }
+
     /*
      * future feature
     public function testTimeIntervalToRunForCanBeConfiguredButItNeedsToProduceAtLeastHalfOfTheIterationsByDefault()

--- a/src/Quantifier/Size.php
+++ b/src/Quantifier/Size.php
@@ -72,6 +72,10 @@ class Size implements Countable
 
     public function limit($maximumNumber)
     {
+        if ($maximumNumber === 1) {
+            return new self([$this->at(0)]);
+        }
+
         $uniformSample = [];
         $factor = count($this->list) / ($maximumNumber - 1);
         for ($i = 0; $i < $maximumNumber; $i++) {

--- a/test/ExampleEnd2EndTest.php
+++ b/test/ExampleEnd2EndTest.php
@@ -117,6 +117,11 @@ class ExampleEnd2EndTest extends \PHPUnit\Framework\TestCase
             (string) $this->theTest('testNumberOfIterationsCanBeConfigured')->attributes()['assertions'],
             "We configured a small number of iterations for this test, but a different number were performed"
         );
+        $this->assertEquals(
+            1,
+            (string) $this->theTest('testSingleIterationCanBeConfigured')->attributes()['assertions'],
+            "We configured a single iteration for this test, but a different number were performed"
+        );
         $this->assertLessThan(
             100,
             (string) $this->theTest('testTimeIntervalToRunForCanBeConfiguredAndAVeryLowNumberOfIterationsCanBeIgnored')->attributes()['assertions'],

--- a/test/Quantifier/SizeTest.php
+++ b/test/Quantifier/SizeTest.php
@@ -31,6 +31,16 @@ class SizeTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(4, $size->at(4));
     }
 
+    public function testLimitsToTheInitialSizeForOneIteration()
+    {
+        $size = Size::withTriangleGrowth(1000)
+            ->limit(1);
+
+        $this->assertCount(1, $size);
+        $this->assertEquals(0, $size->at(0));
+        $this->assertEquals(0, $size->at(1));
+    }
+
     public static function limits()
     {
         return [


### PR DESCRIPTION
A property configured to run once currently fails while constructing its size
schedule: `Size::limit(1)` divides by zero.

Return a one-element schedule containing the initial size instead. This lets
`#[ErisRepeat(repeat: 1)]` execute its one generated example at size zero.

Regressions cover the scheduler directly and verify through the public repeat
attribute that exactly one iteration runs.
